### PR TITLE
Fix property write/data-loss bugs, prune analytics, lock appointments

### DIFF
--- a/somewheria_app/services/analytics.py
+++ b/somewheria_app/services/analytics.py
@@ -16,11 +16,26 @@ class AnalyticsTracker:
         self.logins = collections.defaultdict(int)
         self.errors = collections.defaultdict(int)
 
+    def _prune_old_buckets(self, today: str) -> None:
+        # Keep only the rolling window of ``analytics_days`` so the counters
+        # don't grow unbounded over the lifetime of the process.
+        try:
+            cutoff = (
+                datetime.date.fromisoformat(today)
+                - datetime.timedelta(days=max(0, self.analytics_days))
+            ).isoformat()
+        except ValueError:
+            return
+        for bucket in (self.site_visits, self.unique_users, self.logins, self.errors):
+            for day in [d for d in bucket.keys() if d < cutoff]:
+                del bucket[day]
+
     def before_request(self) -> None:
         g.start_time = time.time()
         if request.endpoint == "static":
             return
         today = datetime.date.today().isoformat()
+        self._prune_old_buckets(today)
         self.site_visits[today] += 1
         user = session.get("user") or {}
         visitor = user.get("email") or request.remote_addr or "anonymous"
@@ -44,11 +59,13 @@ class AnalyticsTracker:
 
     def record_login(self, user_identifier: str) -> None:
         today = datetime.date.today().isoformat()
+        self._prune_old_buckets(today)
         self.logins[today] += 1
         self.unique_users[today].add(user_identifier)
 
     def record_error(self) -> None:
         today = datetime.date.today().isoformat()
+        self._prune_old_buckets(today)
         self.errors[today] += 1
 
     def dashboard_data(self, property_count: int) -> tuple[dict, dict]:

--- a/somewheria_app/services/appointments.py
+++ b/somewheria_app/services/appointments.py
@@ -1,3 +1,5 @@
+import threading
+
 from .console import get_console_logger
 
 
@@ -5,6 +7,9 @@ class AppointmentService:
     def __init__(self, config) -> None:
         self.config = config
         self.logger = get_console_logger("appointments")
+        # Serialize reads/writes against the appointments file so concurrent
+        # save() calls cannot interleave and corrupt the line-oriented data.
+        self._lock = threading.Lock()
 
     def print_check_file(self, path, purpose: str) -> None:
         abs_path = path.resolve()
@@ -18,22 +23,24 @@ class AppointmentService:
         if not self.config.property_appointments_file.exists():
             self.logger.info("Appointments file does not exist yet: %s", abs_path)
             return appointments
-        with self.config.property_appointments_file.open("r", encoding="utf-8") as handle:
-            for raw_line in handle:
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    property_id, dates = line.split(":", 1)
-                    appointments[property_id.strip()] = {item for item in dates.split(",") if item}
-                except Exception:
-                    continue
+        with self._lock:
+            with self.config.property_appointments_file.open("r", encoding="utf-8") as handle:
+                for raw_line in handle:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        property_id, dates = line.split(":", 1)
+                        appointments[property_id.strip()] = {item for item in dates.split(",") if item}
+                    except Exception:
+                        continue
         return appointments
 
     def save(self, appointments: dict[str, set[str]]) -> None:
         abs_path = self.config.property_appointments_file.resolve()
         self.logger.info("Saving %s appointment sets to %s", len(appointments), abs_path)
-        with self.config.property_appointments_file.open("w", encoding="utf-8") as handle:
-            for property_id, date_set in appointments.items():
-                print(f"{property_id}:{','.join(sorted(date_set))}", file=handle)
+        with self._lock:
+            with self.config.property_appointments_file.open("w", encoding="utf-8") as handle:
+                for property_id, date_set in appointments.items():
+                    print(f"{property_id}:{','.join(sorted(date_set))}", file=handle)
         self.print_check_file(self.config.property_appointments_file, "Appointments saved")

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -180,7 +180,9 @@ class PropertyService:
 
     def _safe_json(self, url: str, default):
         try:
-            return requests.get(url, timeout=10).json()
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            return response.json()
         except Exception:
             return default
 
@@ -282,6 +284,7 @@ class PropertyService:
             "address": form.get("address", ""),
             "rent": form.get("rent", ""),
             "deposit": form.get("deposit", ""),
+            "sqft": form.get("sqft", ""),
             "bedrooms": form.get("bedrooms", ""),
             "bathrooms": form.get("bathrooms", ""),
             "lease_length": form.get("lease_length", "12 months"),
@@ -315,6 +318,7 @@ class PropertyService:
                 "address": form.get("address", current_property.get("address")),
                 "rent": form.get("rent", current_property.get("rent")),
                 "deposit": form.get("deposit", current_property.get("deposit")),
+                "sqft": form.get("sqft", current_property.get("sqft", "")),
                 "bedrooms": form.get("bedrooms", current_property.get("bedrooms")),
                 "bathrooms": form.get("bathrooms", current_property.get("bathrooms")),
                 "lease_length": form.get("lease_length", current_property.get("lease_length")),
@@ -338,6 +342,7 @@ class PropertyService:
             "address": updated_property.get("address"),
             "rent": updated_property.get("rent"),
             "deposit": updated_property.get("deposit"),
+            "sqft": updated_property.get("sqft", ""),
             "bedrooms": updated_property.get("bedrooms"),
             "bathrooms": updated_property.get("bathrooms"),
             "lease_length": updated_property.get("lease_length"),
@@ -346,11 +351,14 @@ class PropertyService:
             "description": updated_property.get("description"),
             "included_amenities": updated_property.get("included_amenities", []),
         }
-        requests.put(
+        # Verify the upstream accepted the change before logging it as an
+        # update — otherwise a 4xx/5xx silently records a phantom change.
+        response = requests.put(
             f"{self.config.api_base_url}/properties/{property_id}/details",
             json=update_payload,
             timeout=20,
         )
+        response.raise_for_status()
         self.notifications.log_site_change(actor_email, "property_updated", {"property_id": property_id})
         self.trigger_background_refresh(actor_email)
 
@@ -367,11 +375,14 @@ class PropertyService:
         if not property_info:
             raise KeyError("Property not found")
         new_status = not property_info.get("for_sale", False)
-        requests.put(
+        # Apply upstream first; if the API rejects the change, we must NOT
+        # update the local cache, otherwise the UI would show stale state.
+        response = requests.put(
             f"{self.config.api_base_url}/properties/{property_id}/details",
             json={"for_sale": new_status},
             timeout=20,
         )
+        response.raise_for_status()
         with self.cache_lock:
             for item in self.cache:
                 if item.get("id") == property_id:

--- a/test_services.py
+++ b/test_services.py
@@ -436,5 +436,123 @@ class NotificationServiceTestCase(unittest.TestCase):
         self.assertIn("[http] GET /admin/status -> 200", entries[1]["message"])
 
 
+class PropertyWritePathTestCase(unittest.TestCase):
+    def setUp(self):
+        self.notifications = Mock()
+        self.config = SimpleNamespace(
+            api_base_url="https://api.example.com",
+            upload_dir=Path(tempfile.gettempdir()),
+        )
+        self.service = PropertyService(self.config, self.notifications)
+
+    def test_property_payload_from_form_includes_sqft(self):
+        form = DummyForm(values={"name": "Maple", "sqft": "1200"})
+
+        payload = self.service.property_payload_from_form(form)
+
+        self.assertEqual(payload["sqft"], "1200")
+
+    def test_update_property_forwards_sqft_to_upstream(self):
+        current = {
+            "id": "prop-1",
+            "name": "Maple",
+            "address": "123 Main",
+            "rent": "1000",
+            "deposit": "1000",
+            "sqft": "900",
+            "bedrooms": "2",
+            "bathrooms": "1",
+            "lease_length": "12 months",
+            "pets_allowed": "No",
+            "blurb": "Old",
+            "description": "Old description",
+        }
+        form = DummyForm(values={"sqft": "1500"})
+
+        with patch.object(self.service, "get_property", return_value=current), patch(
+            "somewheria_app.services.properties.requests.put"
+        ) as put_mock, patch.object(self.service, "trigger_background_refresh"):
+            self.service.update_property("prop-1", form, "admin@example.com")
+
+        self.assertEqual(put_mock.call_args.kwargs["json"]["sqft"], "1500")
+
+    def test_update_property_raises_when_upstream_rejects(self):
+        current = {"id": "prop-1", "name": "Maple"}
+        form = DummyForm(values={"name": "Updated"})
+        response = Mock()
+        response.raise_for_status.side_effect = RuntimeError("upstream 500")
+
+        with patch.object(self.service, "get_property", return_value=current), patch(
+            "somewheria_app.services.properties.requests.put",
+            return_value=response,
+        ), patch.object(self.service, "trigger_background_refresh") as trigger_mock:
+            with self.assertRaises(RuntimeError):
+                self.service.update_property("prop-1", form, "admin@example.com")
+
+        # The upstream rejected, so we must NOT log the change or kick a refresh.
+        self.notifications.log_site_change.assert_not_called()
+        trigger_mock.assert_not_called()
+
+    def test_toggle_sale_does_not_update_cache_when_upstream_fails(self):
+        self.service.cache = [{"id": "prop-1", "for_sale": False, "status": "Active"}]
+        response = Mock()
+        response.raise_for_status.side_effect = RuntimeError("upstream 500")
+
+        with patch(
+            "somewheria_app.services.properties.requests.put",
+            return_value=response,
+        ):
+            with self.assertRaises(RuntimeError):
+                self.service.toggle_sale("prop-1", "admin@example.com")
+
+        self.assertFalse(self.service.cache[0]["for_sale"])
+        self.assertEqual(self.service.cache[0]["status"], "Active")
+        self.notifications.log_site_change.assert_not_called()
+
+    def test_safe_json_returns_default_on_http_error_status(self):
+        response = Mock()
+        response.raise_for_status.side_effect = RuntimeError("404")
+        with patch(
+            "somewheria_app.services.properties.requests.get",
+            return_value=response,
+        ):
+            payload = self.service._safe_json("https://example.com/data", ["fallback"])
+
+        self.assertEqual(payload, ["fallback"])
+
+
+class AnalyticsPruningTestCase(unittest.TestCase):
+    def test_prune_drops_buckets_outside_window(self):
+        from somewheria_app.services.analytics import AnalyticsTracker
+
+        tracker = AnalyticsTracker(analytics_days=3)
+        tracker.site_visits["2024-01-01"] = 5  # well outside the 3-day window
+        tracker.unique_users["2024-01-01"] = {"old@example.com"}
+        tracker.logins["2024-01-01"] = 1
+        tracker.errors["2024-01-01"] = 2
+
+        # Today happens to be 2026-05-01 in this test environment but the
+        # prune logic uses whatever string we pass in, so this is independent
+        # of wall-clock time.
+        tracker._prune_old_buckets("2030-01-10")
+
+        self.assertNotIn("2024-01-01", tracker.site_visits)
+        self.assertNotIn("2024-01-01", tracker.unique_users)
+        self.assertNotIn("2024-01-01", tracker.logins)
+        self.assertNotIn("2024-01-01", tracker.errors)
+
+    def test_prune_keeps_recent_days(self):
+        from somewheria_app.services.analytics import AnalyticsTracker
+
+        tracker = AnalyticsTracker(analytics_days=7)
+        tracker.site_visits["2030-01-08"] = 4  # 2 days before "today"
+        tracker.site_visits["2030-01-10"] = 1  # the test "today"
+
+        tracker._prune_old_buckets("2030-01-10")
+
+        self.assertEqual(tracker.site_visits["2030-01-08"], 4)
+        self.assertEqual(tracker.site_visits["2030-01-10"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Backend-only fixes for several real issues found while surveying `somewheria_app/`:

### Bugs fixed
- **`sqft` silently dropped on property create/update.** The edit-listing form has a `sqft` input but `property_payload_from_form` and `update_property` never forwarded it to the upstream API, so users editing a listing's square-footage saw their changes discarded.
- **`toggle_sale` updated the local cache before checking the upstream PUT.** A 5xx from upstream left local and remote in inconsistent state. Now we `raise_for_status()` first and only mutate the cache if upstream accepted.
- **`update_property` ignored upstream PUT failures.** A failing write was still logged as `property_updated` and triggered a cache refresh. Now it raises so the route's error handler kicks in.
- **`_safe_json` returned 4xx/5xx response bodies as data.** A 500 with a JSON error body would replace the photos list. Now we validate via `raise_for_status()`.

### Other improvements
- **Analytics counters were a slow memory leak.** `site_visits`, `unique_users`, `logins`, `errors` are `defaultdict`s that grew forever. Added `_prune_old_buckets` called on every write so dicts are bounded by the rolling `analytics_days` window.
- **Appointments file lacked a lock.** `AppointmentService.save`/`load` now serialize through a per-instance `threading.Lock`, matching the pattern in `FileStorageService`.

### Tests
7 new cases in `test_services.py`:
- `property_payload_from_form` includes `sqft`
- `update_property` forwards `sqft` and raises on upstream rejection
- `toggle_sale` does not mutate cache when upstream fails
- `_safe_json` returns the default on HTTP error status
- analytics pruning drops out-of-window days and keeps recent ones

Full suite: `565 passed, 1 skipped` (was 558, +7).

## Test plan
- [x] `pytest` (all 565 tests pass)
- [ ] Smoke-check `/for-rent` and `/admin/dashboard` after merge
- [ ] Verify a real `sqft` edit round-trips through the upstream API

https://claude.ai/code/session_016utajUcWF9bUw73TfwWCmw

---
_Generated by [Claude Code](https://claude.ai/code/session_016utajUcWF9bUw73TfwWCmw)_