### PR TITLE
Backend hardening: atomic appointments save, image DoS guard, upstream HTTP errors, crash-state bound

### DIFF
--- a/somewheria_app/__init__.py
+++ b/somewheria_app/__init__.py
@@ -128,11 +128,21 @@ def create_app() -> Flask:
 
     def _send_crash_email_async(subject: str, body: str, fingerprint: str) -> None:
         now = time.time()
+        cooldown = crash_email_state["cooldown_seconds"]
         with crash_email_state["lock"]:
-            last = crash_email_state["last_sent_by_key"].get(fingerprint, 0)
-            if now - last < crash_email_state["cooldown_seconds"]:
+            sent = crash_email_state["last_sent_by_key"]
+            last = sent.get(fingerprint, 0)
+            if now - last < cooldown:
                 return  # Already alerted on this error recently; skip.
-            crash_email_state["last_sent_by_key"][fingerprint] = now
+            # Bound the dict so a long-running process that hits many distinct
+            # error fingerprints can't grow this map without limit. Anything
+            # older than the cooldown window can no longer suppress emails, so
+            # it's safe to drop.
+            cutoff = now - cooldown
+            stale = [key for key, ts in sent.items() if ts < cutoff]
+            for key in stale:
+                del sent[key]
+            sent[fingerprint] = now
 
         def _worker() -> None:
             try:

--- a/somewheria_app/services/appointments.py
+++ b/somewheria_app/services/appointments.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import threading
 
 from .console import get_console_logger
@@ -37,10 +39,26 @@ class AppointmentService:
         return appointments
 
     def save(self, appointments: dict[str, set[str]]) -> None:
-        abs_path = self.config.property_appointments_file.resolve()
+        # Atomic write: render the full payload to a sibling temp file, fsync,
+        # then os.replace() over the destination. A crash mid-write leaves the
+        # original file intact instead of a half-written, truncated one.
+        path = self.config.property_appointments_file
+        abs_path = path.resolve()
         self.logger.info("Saving %s appointment sets to %s", len(appointments), abs_path)
         with self._lock:
-            with self.config.property_appointments_file.open("w", encoding="utf-8") as handle:
-                for property_id, date_set in appointments.items():
-                    print(f"{property_id}:{','.join(sorted(date_set))}", file=handle)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    for property_id, date_set in appointments.items():
+                        print(f"{property_id}:{','.join(sorted(date_set))}", file=handle)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_name, path)
+            except Exception:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
         self.print_check_file(self.config.property_appointments_file, "Appointments saved")

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -160,9 +160,19 @@ class PropertyService:
 
     def fetch_property_record(self, property_id: str):
         try:
-            details = requests.get(
+            details_response = requests.get(
                 f"{self.config.api_base_url}/properties/{property_id}/details", timeout=10
-            ).json()
+            )
+            # Without raise_for_status() a 4xx/5xx JSON error body would be
+            # silently passed through as a property record.
+            details_response.raise_for_status()
+            details = details_response.json()
+            if not isinstance(details, dict):
+                self.logger.warning(
+                    "Property %s details endpoint returned non-object payload; skipping",
+                    property_id,
+                )
+                return None
             photo_urls = self._safe_json(f"{self.config.api_base_url}/properties/{property_id}/photos", [])
             thumbnail_url = self._safe_json(
                 f"{self.config.api_base_url}/properties/{property_id}/thumbnail", None
@@ -262,13 +272,31 @@ class PropertyService:
 
     def get_base64_image_from_url(self, url: str):
         try:
-            image_response = requests.get(url, timeout=10)
-            image_response.raise_for_status()
-            with Image.open(BytesIO(image_response.content)) as image:
-                processed = self.letterbox_to_16_9(ImageOps.exif_transpose(image).convert("RGB"))
+            # Stream the download with a hard byte cap so a misbehaving or
+            # hostile upstream can't exhaust memory by serving an enormous
+            # payload. Reject early via Content-Length when present, then
+            # enforce the cap during streaming for chunked / unknown-length
+            # responses.
+            with requests.get(url, timeout=10, stream=True) as image_response:
+                image_response.raise_for_status()
+                advertised = image_response.headers.get("Content-Length")
+                if advertised and advertised.isdigit() and int(advertised) > MAX_IMAGE_BYTES:
+                    raise ValueError(f"Image exceeds {MAX_IMAGE_BYTES} byte limit")
                 buffer = BytesIO()
-                processed.save(buffer, format="JPEG")
-                encoded = base64.b64encode(buffer.getvalue()).decode("utf-8")
+                total = 0
+                for chunk in image_response.iter_content(chunk_size=64 * 1024):
+                    if not chunk:
+                        continue
+                    total += len(chunk)
+                    if total > MAX_IMAGE_BYTES:
+                        raise ValueError(f"Image exceeds {MAX_IMAGE_BYTES} byte limit")
+                    buffer.write(chunk)
+                raw = buffer.getvalue()
+            with Image.open(BytesIO(raw)) as image:
+                processed = self.letterbox_to_16_9(ImageOps.exif_transpose(image).convert("RGB"))
+                out = BytesIO()
+                processed.save(out, format="JPEG")
+                encoded = base64.b64encode(out.getvalue()).decode("utf-8")
                 return f"data:image/jpeg;base64,{encoded}"
         except Exception as exc:
             self.logger.warning("Could not process image %s: %s", url, exc)

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 from flask import Flask, Response, abort
 from PIL import Image
@@ -275,7 +275,12 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         image = Image.new("RGB", (16, 9), color="green")
         buffer = io.BytesIO()
         image.save(buffer, format="PNG")
-        response = Mock(content=buffer.getvalue())
+        payload = buffer.getvalue()
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.headers = {"Content-Length": str(len(payload))}
+        response.raise_for_status.return_value = None
+        response.iter_content.return_value = iter([payload])
 
         with patch("somewheria_app.services.properties.requests.get", return_value=response):
             encoded = self.service.get_base64_image_from_url("https://example.com/image.png")

--- a/test_services.py
+++ b/test_services.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 from somewheria_app.services.appointments import AppointmentService
 from somewheria_app.services.auth import AuthService
@@ -172,33 +172,50 @@ class FileStorageServiceTestCase(unittest.TestCase):
 
 class AppointmentServiceTestCase(unittest.TestCase):
     def setUp(self):
-        self.config = SimpleNamespace(property_appointments_file=Path("appointments.txt"))
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.appointments_path = Path(self.tmpdir.name) / "appointments.txt"
+        self.config = SimpleNamespace(property_appointments_file=self.appointments_path)
         self.service = AppointmentService(self.config)
 
     def test_load_returns_empty_when_file_missing(self):
-        with patch.object(Path, "exists", return_value=False):
-            self.assertEqual(self.service.load(), {})
+        self.assertEqual(self.service.load(), {})
 
     def test_save_and_load_round_trip(self):
-        handle = mock_open()
-        with patch.object(Path, "open", handle), patch.object(
-            self.service,
-            "print_check_file",
-        ) as print_check_mock:
-            self.service.save({"prop-1": {"2030-01-11", "2030-01-10"}})
+        self.service.save({"prop-1": {"2030-01-11", "2030-01-10"}, "prop-2": {"2030-02-01"}})
+        loaded = self.service.load()
+        self.assertEqual(loaded["prop-1"], {"2030-01-10", "2030-01-11"})
+        self.assertEqual(loaded["prop-2"], {"2030-02-01"})
+        # Dates should be persisted in sorted order on disk.
+        on_disk = self.appointments_path.read_text(encoding="utf-8")
+        self.assertIn("prop-1:2030-01-10,2030-01-11", on_disk)
 
-        written = "".join(call.args[0] for call in handle().write.call_args_list)
-        self.assertIn("prop-1:2030-01-10,2030-01-11", written)
-        print_check_mock.assert_called_once()
+    def test_save_is_atomic_no_temp_files_left_behind(self):
+        self.service.save({"prop-1": {"2030-01-10"}})
+        leftovers = [p for p in self.appointments_path.parent.iterdir() if p.name != "appointments.txt"]
+        self.assertEqual(leftovers, [], f"Unexpected temp files: {leftovers}")
+
+    def test_save_failure_preserves_existing_file(self):
+        # First save establishes the original contents we want preserved.
+        self.service.save({"prop-1": {"2030-01-10"}})
+        original = self.appointments_path.read_text(encoding="utf-8")
+
+        # Force the os.replace step to fail; the original file must survive
+        # untouched and no leftover temp file may remain.
+        with patch("somewheria_app.services.appointments.os.replace", side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                self.service.save({"prop-1": {"2099-12-31"}})
+
+        self.assertEqual(self.appointments_path.read_text(encoding="utf-8"), original)
+        leftovers = [p for p in self.appointments_path.parent.iterdir() if p.name != "appointments.txt"]
+        self.assertEqual(leftovers, [], f"Temp file leaked after failed save: {leftovers}")
 
     def test_load_ignores_malformed_lines(self):
-        with patch.object(Path, "exists", return_value=True), patch.object(
-            Path,
-            "open",
-            mock_open(read_data="prop-1:2030-01-10,2030-01-11\nmalformed\nprop-2:2030-02-01\n"),
-        ):
-            loaded = self.service.load()
-
+        self.appointments_path.write_text(
+            "prop-1:2030-01-10,2030-01-11\nmalformed\nprop-2:2030-02-01\n",
+            encoding="utf-8",
+        )
+        loaded = self.service.load()
         self.assertEqual(loaded["prop-1"], {"2030-01-10", "2030-01-11"})
         self.assertEqual(loaded["prop-2"], {"2030-02-01"})
 
@@ -320,6 +337,60 @@ class PropertyServiceTestCase(unittest.TestCase):
             name = self.service.fetch_live_property_name("prop-1")
 
         self.assertIsNone(name)
+
+    def test_fetch_property_record_returns_none_on_http_error(self):
+        # Upstream returns valid JSON but with a 5xx status code. Without
+        # raise_for_status() the error body would be passed through as a
+        # property record.
+        from requests import HTTPError
+
+        details_response = Mock()
+        details_response.raise_for_status.side_effect = HTTPError("500")
+        details_response.json.return_value = {"error": "boom"}
+
+        with patch(
+            "somewheria_app.services.properties.requests.get",
+            return_value=details_response,
+        ):
+            self.assertIsNone(self.service.fetch_property_record("prop-1"))
+
+    def test_fetch_property_record_skips_non_dict_payload(self):
+        details_response = Mock()
+        details_response.raise_for_status.return_value = None
+        details_response.json.return_value = ["not", "a", "dict"]
+
+        with patch(
+            "somewheria_app.services.properties.requests.get",
+            return_value=details_response,
+        ):
+            self.assertIsNone(self.service.fetch_property_record("prop-1"))
+
+    def test_get_base64_image_from_url_rejects_oversize_content_length(self):
+        from somewheria_app.services.properties import MAX_IMAGE_BYTES
+
+        oversize = MAX_IMAGE_BYTES + 1
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.headers = {"Content-Length": str(oversize)}
+        response.raise_for_status.return_value = None
+        response.iter_content.return_value = iter([])
+
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            self.assertIsNone(self.service.get_base64_image_from_url("https://example.com/big.jpg"))
+
+    def test_get_base64_image_from_url_rejects_oversize_streamed(self):
+        from somewheria_app.services.properties import MAX_IMAGE_BYTES
+
+        # No Content-Length header (chunked / unknown size); the cap must be
+        # enforced while iterating chunks.
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.headers = {}
+        response.raise_for_status.return_value = None
+        response.iter_content.return_value = iter([b"x" * (MAX_IMAGE_BYTES + 1)])
+
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            self.assertIsNone(self.service.get_base64_image_from_url("https://example.com/big.jpg"))
 
 
 class NotificationServiceTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

Backend-only hardening across four real bugs surfaced while surveying `somewheria_app/`.

- **Data-loss fix — atomic appointments save.** `AppointmentService.save` opened the destination file in `"w"` mode and wrote line-by-line. A crash or kill mid-write left every booked appointment truncated. Now it renders the full payload to a sibling temp file, fsyncs, and `os.replace`s — same pattern `FileStorageService.save_json_file` already uses. Failures clean up the temp file and leave the original intact.
- **DoS guard — bounded remote image downloads.** `PropertyService.get_base64_image_from_url` previously called `requests.get(...).content`, pulling whatever the upstream returned into memory. It now streams with a hard `MAX_IMAGE_BYTES` (16 MB) cap, rejecting both oversized `Content-Length` headers and oversized chunked bodies before they OOM the worker.
- **Upstream HTTP error handling.** `PropertyService.fetch_property_record` chained `.json()` directly off the request, so a 4xx/5xx JSON error body would be passed through as a property record. It now calls `raise_for_status()` and skips non-dict payloads.
- **Memory bound — crash-handler de-dup map.** `crash_email_state["last_sent_by_key"]` accumulated one entry per `(error_class, path)` fingerprint forever. The map is now pruned on each new alert by dropping keys older than the cooldown window — they can no longer suppress emails anyway.

Updated/added tests: appointments save round-trip + atomicity + failure-preservation (rewritten against a real tmpdir instead of mock-patched `Path.open`), `fetch_property_record` HTTP-error and non-dict-payload paths, oversized-image rejection by both Content-Length and streamed chunks. Updated the existing `test_get_base64_image_from_url_returns_data_url` to mock the new streaming interface.

## Test plan

- [x] Full suite green locally: `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 572 tests pass (1 skipped, the OAuth env-var test).
- [x] App boots cleanly with all 47 routes registered.
- [x] CI workflow (`Flask CI/CD`) green on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_013evLooQqRSbYCGQ9J1wdxp)_