### PR TITLE
Backend hardening: input validation at boundaries and bounded log read

### DIFF
--- a/somewheria_app/services/notifications.py
+++ b/somewheria_app/services/notifications.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import html
 import json
@@ -106,10 +107,13 @@ class NotificationService:
             self.console.error("Failed to record site change '%s': %s", action, exc)
 
     def read_logs(self) -> list[dict]:
-        entries = []
         if not self.config.log_file.exists():
-            return entries
+            return []
         ansi_escape = re.compile(r"\x1B\[[0-9;]*[mK]")
+        # Bound peak memory: a long-running process can produce a multi-MB
+        # log file, but the UI only ever shows the last 500 entries. A deque
+        # keeps just the tail in memory instead of the entire history.
+        entries: collections.deque[dict] = collections.deque(maxlen=500)
         with self.config.log_file.open("r", encoding="utf-8", errors="replace") as handle:
             for raw_line in handle:
                 line = raw_line.strip()
@@ -139,4 +143,4 @@ class NotificationService:
                         "message": ansi_escape.sub("", message),
                     }
                 )
-        return list(reversed(entries[-500:]))
+        return list(reversed(entries))

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -159,6 +159,12 @@ class PropertyService:
             return []
 
     def fetch_property_record(self, property_id: str):
+        # Defense in depth: refuse property IDs that don't match the expected
+        # shape so a malformed upstream response can't smuggle traversal
+        # sequences ("../") into our outbound HTTP paths.
+        if not PROPERTY_ID_PATTERN.match(property_id or ""):
+            self.logger.warning("Refusing to fetch property with invalid id: %r", property_id)
+            return None
         try:
             details_response = requests.get(
                 f"{self.config.api_base_url}/properties/{property_id}/details", timeout=10
@@ -173,12 +179,20 @@ class PropertyService:
                     property_id,
                 )
                 return None
-            photo_urls = self._safe_json(f"{self.config.api_base_url}/properties/{property_id}/photos", [])
+            photo_urls = self._safe_json(
+                f"{self.config.api_base_url}/properties/{property_id}/photos",
+                [],
+                expected_type=list,
+            )
             thumbnail_url = self._safe_json(
-                f"{self.config.api_base_url}/properties/{property_id}/thumbnail", None
+                f"{self.config.api_base_url}/properties/{property_id}/thumbnail",
+                None,
+                expected_type=str,
             )
             details["photos"] = []
             for photo_url in photo_urls:
+                if not isinstance(photo_url, str):
+                    continue
                 encoded = self.get_base64_image_from_url(photo_url)
                 if encoded:
                     details["photos"].append(encoded)
@@ -188,13 +202,16 @@ class PropertyService:
             self.logger.warning("Failed to fetch property %s: %s", property_id, exc)
             return None
 
-    def _safe_json(self, url: str, default):
+    def _safe_json(self, url: str, default, *, expected_type: type | tuple[type, ...] | None = None):
         try:
             response = requests.get(url, timeout=10)
             response.raise_for_status()
-            return response.json()
+            payload = response.json()
         except Exception:
             return default
+        if expected_type is not None and not isinstance(payload, expected_type):
+            return default
+        return payload
 
     def normalize_property(self, property_info: dict, property_id: str | None = None) -> dict:
         normalized = dict(property_info or {})
@@ -494,11 +511,25 @@ class PropertyService:
         return relative_url
 
     def fetch_live_property_name(self, property_id: str) -> str | None:
+        # Validate the id at the boundary so unsanitized values can't smuggle
+        # path-traversal sequences ("../") into the outbound URL.
+        if not PROPERTY_ID_PATTERN.match(property_id or ""):
+            return None
         try:
-            property_info = requests.get(
+            response = requests.get(
                 f"{self.config.api_base_url}/properties/{property_id}/details",
                 timeout=10,
-            ).json()
-            return property_info.get("name", "(Unknown Property)")
+            )
+            # Without raise_for_status() a 404/5xx JSON error body would be
+            # treated as a real property and the caller would proceed as if
+            # the property existed.
+            response.raise_for_status()
+            property_info = response.json()
         except Exception:
             return None
+        if not isinstance(property_info, dict):
+            return None
+        name = property_info.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return None
+        return name

--- a/somewheria_app/services/storage.py
+++ b/somewheria_app/services/storage.py
@@ -12,12 +12,25 @@ class FileStorageService:
         self.file_lock = threading.Lock()
         self.logger = get_console_logger("storage")
 
-    def load_json_file(self, path, default):
+    def load_json_file(self, path, default, *, expected_type: type | tuple[type, ...] | None = None):
         try:
             with self.file_lock:
                 if path.exists():
                     with path.open("r", encoding="utf-8") as handle:
-                        return json.load(handle)
+                        loaded = json.load(handle)
+                    # If the caller declared an expected shape, fall back to
+                    # the default when the file's contents don't match. Without
+                    # this, a corrupted or hand-edited file holding a dict
+                    # where a list is expected would crash callers that do
+                    # ``.append`` or list-iteration on the return value.
+                    if expected_type is not None and not isinstance(loaded, expected_type):
+                        self.logger.warning(
+                            "Unexpected JSON shape in %s (got %s); using default",
+                            path,
+                            type(loaded).__name__,
+                        )
+                        return default
+                    return loaded
         except Exception as exc:
             self.logger.error("Failed to load %s: %s", path, exc)
         return default
@@ -45,7 +58,7 @@ class FileStorageService:
             self.logger.error("Failed to save %s: %s", path, exc)
 
     def get_pending_registrations(self) -> list[dict]:
-        return self.load_json_file(self.config.registration_file, [])
+        return self.load_json_file(self.config.registration_file, [], expected_type=list)
 
     def add_pending_registration(self, registration: dict) -> None:
         registrations = self.get_pending_registrations()
@@ -59,7 +72,7 @@ class FileStorageService:
         self.save_json_file(self.config.registration_file, registrations)
 
     def get_user_roles(self) -> dict:
-        return self.load_json_file(self.config.user_roles_file, {})
+        return self.load_json_file(self.config.user_roles_file, {}, expected_type=dict)
 
     def set_user_role(self, email: str, role: str) -> None:
         roles = self.get_user_roles()
@@ -78,13 +91,13 @@ class FileStorageService:
         return previous is not None and previous != "revoked"
 
     def get_renter_profiles(self) -> dict:
-        return self.load_json_file(self.config.renter_profile_file, {})
+        return self.load_json_file(self.config.renter_profile_file, {}, expected_type=dict)
 
     def save_renter_profiles(self, profiles: dict) -> None:
         self.save_json_file(self.config.renter_profile_file, profiles)
 
     def get_renter_contracts(self) -> dict:
-        return self.load_json_file(self.config.contracts_file, {})
+        return self.load_json_file(self.config.contracts_file, {}, expected_type=dict)
 
     def save_renter_contracts(self, contracts: dict) -> None:
         self.save_json_file(self.config.contracts_file, contracts)

--- a/test_services.py
+++ b/test_services.py
@@ -98,6 +98,33 @@ class FileStorageServiceTestCase(unittest.TestCase):
 
         self.assertEqual(loaded, {"admin@example.com": "admin"})
 
+    def test_load_json_file_falls_back_when_expected_type_does_not_match(self):
+        # File exists and contains valid JSON, but it's a dict where the
+        # caller asked for a list. Without the type check, downstream code
+        # that does ``.append`` on the return value would crash.
+        with patch.object(Path, "exists", return_value=True), patch.object(
+            Path,
+            "open",
+            mock_open(read_data='{"oops": "wrong shape"}'),
+        ):
+            loaded = self.service.load_json_file(
+                self.config.registration_file, [], expected_type=list
+            )
+
+        self.assertEqual(loaded, [])
+
+    def test_load_json_file_returns_loaded_value_when_type_matches(self):
+        with patch.object(Path, "exists", return_value=True), patch.object(
+            Path,
+            "open",
+            mock_open(read_data='[{"email": "a@example.com"}]'),
+        ):
+            loaded = self.service.load_json_file(
+                self.config.registration_file, [], expected_type=list
+            )
+
+        self.assertEqual(loaded, [{"email": "a@example.com"}])
+
     def test_add_pending_registration_appends_and_saves(self):
         with patch.object(self.service, "get_pending_registrations", return_value=[{"email": "keep@example.com"}]), patch.object(
             self.service,
@@ -338,6 +365,49 @@ class PropertyServiceTestCase(unittest.TestCase):
 
         self.assertIsNone(name)
 
+    def test_fetch_live_property_name_returns_none_for_invalid_id(self):
+        # A traversal-style id must be rejected at the boundary so the
+        # outbound URL can never reach an unintended upstream path.
+        with patch("somewheria_app.services.properties.requests.get") as get_mock:
+            name = self.service.fetch_live_property_name("../../etc/passwd")
+
+        self.assertIsNone(name)
+        get_mock.assert_not_called()
+
+    def test_fetch_live_property_name_returns_none_on_http_error_status(self):
+        # A 404/5xx with a JSON error body must not be treated as a real
+        # property name. Without raise_for_status() this would have leaked
+        # through and the caller would have proceeded as if the property
+        # existed.
+        from requests import HTTPError
+
+        response = Mock()
+        response.raise_for_status.side_effect = HTTPError("404")
+        response.json.return_value = {"name": "Should Be Ignored"}
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            name = self.service.fetch_live_property_name("prop-1")
+
+        self.assertIsNone(name)
+
+    def test_fetch_live_property_name_returns_none_when_name_missing(self):
+        # Upstream answered 200 but the JSON has no usable name; we must
+        # signal "not found" rather than fall back to a generic placeholder
+        # that callers would treat as a successful lookup.
+        response = Mock()
+        response.json.return_value = {"address": "123 Main"}
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            name = self.service.fetch_live_property_name("prop-1")
+
+        self.assertIsNone(name)
+
+    def test_fetch_live_property_name_returns_none_when_payload_not_a_dict(self):
+        response = Mock()
+        response.json.return_value = ["unexpected", "list"]
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            name = self.service.fetch_live_property_name("prop-1")
+
+        self.assertIsNone(name)
+
     def test_fetch_property_record_returns_none_on_http_error(self):
         # Upstream returns valid JSON but with a 5xx status code. Without
         # raise_for_status() the error body would be passed through as a
@@ -506,6 +576,28 @@ class NotificationServiceTestCase(unittest.TestCase):
         self.assertEqual(entries[1]["level"], "INFO")
         self.assertIn("[http] GET /admin/status -> 200", entries[1]["message"])
 
+    def test_read_logs_caps_returned_entries_to_500(self):
+        # A log file with more than 500 entries should still return only the
+        # last 500, in newest-first order. The implementation streams the
+        # file through a bounded deque so memory does not grow with the
+        # number of historical lines.
+        log_text = "".join(
+            f"2026-03-23 18:47:{i % 60:02d}|INFO|http|line {i}\n"
+            for i in range(700)
+        )
+        with patch.object(Path, "exists", return_value=True), patch.object(
+            Path,
+            "open",
+            mock_open(read_data=log_text),
+        ):
+            entries = self.service.read_logs()
+
+        self.assertEqual(len(entries), 500)
+        # Newest entry first.
+        self.assertIn("line 699", entries[0]["message"])
+        # Oldest retained entry is index 200 (700 - 500).
+        self.assertIn("line 200", entries[-1]["message"])
+
 
 class PropertyWritePathTestCase(unittest.TestCase):
     def setUp(self):
@@ -590,6 +682,73 @@ class PropertyWritePathTestCase(unittest.TestCase):
             payload = self.service._safe_json("https://example.com/data", ["fallback"])
 
         self.assertEqual(payload, ["fallback"])
+
+    def test_safe_json_returns_default_when_type_does_not_match(self):
+        # Caller asked for a list but the API answered with an object. The
+        # default must be returned so downstream iteration doesn't quietly
+        # walk the dict's keys.
+        response = Mock()
+        response.json.return_value = {"oops": "object"}
+        with patch(
+            "somewheria_app.services.properties.requests.get",
+            return_value=response,
+        ):
+            payload = self.service._safe_json(
+                "https://example.com/photos", ["fallback"], expected_type=list
+            )
+
+        self.assertEqual(payload, ["fallback"])
+
+    def test_safe_json_returns_payload_when_type_matches(self):
+        response = Mock()
+        response.json.return_value = ["a", "b"]
+        with patch(
+            "somewheria_app.services.properties.requests.get",
+            return_value=response,
+        ):
+            payload = self.service._safe_json(
+                "https://example.com/photos", [], expected_type=list
+            )
+
+        self.assertEqual(payload, ["a", "b"])
+
+    def test_fetch_property_record_skips_invalid_property_id(self):
+        # Defense in depth: even if upstream somehow returned a malformed
+        # id, we must not relay it into an outbound URL.
+        with patch("somewheria_app.services.properties.requests.get") as get_mock:
+            result = self.service.fetch_property_record("../etc")
+
+        self.assertIsNone(result)
+        get_mock.assert_not_called()
+
+    def test_fetch_property_record_ignores_non_string_photo_urls(self):
+        details_response = Mock()
+        details_response.json.return_value = {"name": "House"}
+        photos_response = Mock()
+        # A misbehaving upstream returns a list with non-string entries.
+        # Those must be skipped instead of crashing the image pipeline.
+        photos_response.json.return_value = [42, None, "https://example.com/p.jpg"]
+        thumb_response = Mock()
+        thumb_response.json.return_value = "https://example.com/thumb.jpg"
+
+        responses = {
+            f"{self.service.config.api_base_url}/properties/prop-1/details": details_response,
+            f"{self.service.config.api_base_url}/properties/prop-1/photos": photos_response,
+            f"{self.service.config.api_base_url}/properties/prop-1/thumbnail": thumb_response,
+        }
+
+        def fake_get(url, *args, **kwargs):
+            return responses[url]
+
+        with patch("somewheria_app.services.properties.requests.get", side_effect=fake_get), patch.object(
+            self.service, "get_base64_image_from_url", return_value="data:image/jpeg;base64,xxx"
+        ) as encode_mock:
+            record = self.service.fetch_property_record("prop-1")
+
+        # Only the single string URL should reach the encoder.
+        encode_mock.assert_called_once_with("https://example.com/p.jpg")
+        self.assertIsNotNone(record)
+        self.assertEqual(record["photos"], ["data:image/jpeg;base64,xxx"])
 
 
 class AnalyticsPruningTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

Tightens a few backend boundaries that were silently passing through bad data, and bounds peak memory in `read_logs`.

- **`properties.fetch_live_property_name`**: validate `property_id` against the existing `PROPERTY_ID_PATTERN`, add `raise_for_status()` so a 4xx/5xx with a JSON error body no longer leaks through, and reject blank / non-string names instead of returning a `"(Unknown Property)"` fallback that callers (e.g. `/property/<id>/schedule`) treated as a successful lookup.
- **`properties.fetch_property_record`**: validate `property_id` at the boundary as defense-in-depth, and skip non-string entries in the `photos` list.
- **`properties._safe_json`**: optional `expected_type` guard, so a misbehaving upstream returning a dict where a list is expected falls back to the default instead of letting downstream code iterate dict keys.
- **`storage.load_json_file`**: optional `expected_type` guard, wired into `get_pending_registrations` (list), `get_user_roles` / `get_renter_profiles` / `get_renter_contracts` (dict). Prevents a corrupted or hand-edited JSON file with the wrong shape from crashing routes that do `.append` / dict access on the result.
- **`notifications.read_logs`**: stream the log file through a bounded `collections.deque(maxlen=500)` instead of building the full list and slicing the tail, so peak memory no longer grows with log size.

No template / HTML changes. No new dependencies.

## Test plan

- [x] `python -m unittest discover` &mdash; 583 tests pass (was 572; added 11 covering the new behaviour: property-id validation, HTTP-error-status pass-through prevention, `_safe_json` type guard, non-string photo URL skipping, `load_json_file` type-mismatch fallback, and 500-entry log read cap).
- [x] CI green on this PR.

https://claude.ai/code/session_012jv4NV4QAqV2VtLRMGdPEX

---
_Generated by [Claude Code](https://claude.ai/code/session_012jv4NV4QAqV2VtLRMGdPEX)_