### PR TITLE
Reject decompression-bomb images in upload and upstream-fetch paths

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -10,7 +10,7 @@ import time
 from io import BytesIO
 
 import requests
-from PIL import Image, ImageOps, UnidentifiedImageError
+from PIL import Image, ImageOps
 from flask import url_for
 from werkzeug.utils import secure_filename
 
@@ -19,11 +19,36 @@ from .console import get_console_logger
 
 ALLOWED_IMAGE_EXTENSIONS = {"jpg", "jpeg", "png", "gif", "webp"}
 MAX_IMAGE_BYTES = 16 * 1024 * 1024
+# Bound the decoded raster so a hostile / malformed file can't trigger a
+# multi-gigabyte allocation. A highly-compressed PNG well under MAX_IMAGE_BYTES
+# can decode to tens of thousands of pixels per side, and letterboxing on
+# extreme aspect ratios amplifies that further. 24MP comfortably exceeds any
+# real property photo from a phone or DSLR.
+MAX_IMAGE_PIXELS = 24_000_000
+# Cap any single dimension so an extreme aspect ratio can't blow up the
+# letterbox output even when total pixel count is within MAX_IMAGE_PIXELS.
+MAX_IMAGE_DIMENSION = 6000
 PROPERTY_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+# Tighten Pillow's own decompression-bomb threshold so even if our explicit
+# checks miss a code path, decoding raises rather than silently allocating.
+Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
 
 
 class UploadValidationError(ValueError):
     pass
+
+
+def _ensure_safe_image_dimensions(image: Image.Image) -> None:
+    width, height = image.size
+    if width <= 0 or height <= 0:
+        raise UploadValidationError("Image has invalid dimensions.")
+    if width > MAX_IMAGE_DIMENSION or height > MAX_IMAGE_DIMENSION:
+        raise UploadValidationError(
+            f"Image dimensions exceed {MAX_IMAGE_DIMENSION}px limit."
+        )
+    if width * height > MAX_IMAGE_PIXELS:
+        raise UploadValidationError("Image pixel count exceeds safe limit.")
 
 
 BLANK_PROPERTY = {
@@ -283,6 +308,13 @@ class PropertyService:
         else:
             new_height = height
             new_width = int(height * target_ratio)
+        # Defense in depth: an extreme aspect-ratio input (e.g. very tall)
+        # whose own pixel count is within MAX_IMAGE_PIXELS can still letterbox
+        # to a much larger canvas. Reject rather than allocate the buffer.
+        if new_width * new_height > MAX_IMAGE_PIXELS:
+            raise UploadValidationError(
+                "Image aspect ratio would produce an oversized letterbox."
+            )
         new_image = Image.new("RGB", (new_width, new_height), color=(0, 0, 0))
         new_image.paste(image, ((new_width - width) // 2, (new_height - height) // 2))
         return new_image
@@ -310,6 +342,7 @@ class PropertyService:
                     buffer.write(chunk)
                 raw = buffer.getvalue()
             with Image.open(BytesIO(raw)) as image:
+                _ensure_safe_image_dimensions(image)
                 processed = self.letterbox_to_16_9(ImageOps.exif_transpose(image).convert("RGB"))
                 out = BytesIO()
                 processed.save(out, format="JPEG")
@@ -460,8 +493,11 @@ class PropertyService:
             raise UploadValidationError("Image exceeds maximum allowed size.")
         try:
             with Image.open(BytesIO(raw)) as probe:
+                _ensure_safe_image_dimensions(probe)
                 probe.verify()
-        except (UnidentifiedImageError, Exception) as exc:
+        except UploadValidationError:
+            raise
+        except Exception as exc:
             raise UploadValidationError("File is not a valid image.") from exc
 
         new_filename = f"{property_id}_{secrets.token_hex(8)}.{ext}"

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -396,6 +396,63 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
 
         self.notifications.log_and_notify_error.assert_not_called()
 
+    def test_upload_image_rejects_oversized_dimensions(self):
+        from somewheria_app.services.properties import MAX_IMAGE_DIMENSION
+
+        file_bytes = io.BytesIO()
+        # Tiny on disk but past the per-side dimension cap.
+        Image.new("RGB", (MAX_IMAGE_DIMENSION + 1, 10), color="white").save(
+            file_bytes, format="PNG"
+        )
+
+        class UploadedFile:
+            filename = "huge.png"
+            stream = io.BytesIO(file_bytes.getvalue())
+
+        with self.assertRaises(UploadValidationError) as ctx:
+            self.service.upload_image(
+                "prop-1", UploadedFile(), "https://example.com", "admin@example.com"
+            )
+        self.assertIn(str(MAX_IMAGE_DIMENSION), str(ctx.exception))
+        # Nothing should have been written to disk for a rejected upload.
+        for entry in self.upload_dir.iterdir():
+            self.assertFalse(entry.name.startswith("prop-1_"))
+
+    def test_letterbox_rejects_extreme_aspect_ratio(self):
+        from somewheria_app.services.properties import MAX_IMAGE_DIMENSION
+
+        # A tall, narrow input within the per-side dimension cap whose 16:9
+        # letterbox would amplify pixel count past MAX_IMAGE_PIXELS. Using a
+        # mock keeps the test from actually allocating that buffer.
+        image = Mock()
+        image.size = (100, MAX_IMAGE_DIMENSION)
+        with self.assertRaises(UploadValidationError):
+            self.service.letterbox_to_16_9(image)
+
+    def test_get_base64_image_from_url_rejects_oversized_dimensions(self):
+        from somewheria_app.services.properties import MAX_IMAGE_DIMENSION
+
+        buffer = io.BytesIO()
+        Image.new("RGB", (MAX_IMAGE_DIMENSION + 1, 10), color="white").save(
+            buffer, format="PNG"
+        )
+        payload = buffer.getvalue()
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.headers = {"Content-Length": str(len(payload))}
+        response.raise_for_status.return_value = None
+        response.iter_content.return_value = iter([payload])
+
+        with patch(
+            "somewheria_app.services.properties.requests.get", return_value=response
+        ), patch.object(self.service.logger, "warning") as warning_mock:
+            encoded = self.service.get_base64_image_from_url(
+                "https://example.com/huge.png"
+            )
+
+        self.assertIsNone(encoded)
+        warning_mock.assert_called_once()
+
     def test_upload_image_logs_association_failure(self):
         file_bytes = io.BytesIO()
         Image.new("RGB", (16, 9), color="yellow").save(file_bytes, format="PNG")


### PR DESCRIPTION
The byte cap on image inputs (16MB) doesn't prevent a highly-compressed file from decoding into a multi-gigabyte raster, and letterboxing on extreme aspect ratios amplifies that further. Cap decoded pixel count and per-side dimensions, defensively guard the letterbox amplification, and tighten Pillow's own MAX_IMAGE_PIXELS so any missed code path still raises rather than allocating.