### PR TITLE
Send registration emails to applicant; lock TicketService mutations

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -386,18 +386,24 @@ def admin_registrations():
                 title="Pending Registrations",
                 error="No email provided.",
             )
+        # Send the approval/rejection notice to the applicant, not the admin
+        # inbox. Without an explicit ``to=`` the NotificationService falls back
+        # to ``config.email_recipient`` (admin), so the user-facing message
+        # never reaches them.
         if action == "approve":
             services.storage.set_user_role(email, "renter")
             services.storage.remove_pending_registration(email)
             services.notifications.send_email(
                 "Registration Approved",
                 "Your registration for Somewheria has been approved. You can now log in.",
+                to=email,
             )
         elif action == "reject":
             services.storage.remove_pending_registration(email)
             services.notifications.send_email(
                 "Registration Rejected",
                 "Your registration for Somewheria was not approved at this time.",
+                to=email,
             )
         else:
             return render_template(

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -10,6 +10,7 @@ The service is intentionally small and synchronous — it mirrors the
 from __future__ import annotations
 
 import datetime
+import threading
 import uuid
 from typing import Iterable
 
@@ -57,6 +58,12 @@ class TicketService:
         self.storage = storage
         self.notifications = notifications
         self.logger = get_console_logger("tickets")
+        # Serialize the ``_load -> mutate -> _save`` paths. The underlying
+        # FileStorageService lock only covers a single read or write, so two
+        # concurrent ticket submissions could each load the same list, append,
+        # and one would overwrite the other on save. RLock so a future caller
+        # that already holds the lock can re-enter without deadlocking.
+        self._mutate_lock = threading.RLock()
 
     # ------------------------------------------------------------------ I/O
 
@@ -149,9 +156,10 @@ class TicketService:
             "notes": [],
         }
 
-        tickets = self._load()
-        tickets.append(ticket)
-        self._save(tickets)
+        with self._mutate_lock:
+            tickets = self._load()
+            tickets.append(ticket)
+            self._save(tickets)
 
         try:
             # Notify the internal admin inbox.
@@ -198,23 +206,28 @@ class TicketService:
         return ticket
 
     def set_email_updates(self, ticket_id: str, enabled: bool, actor_email: str) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            ticket["email_updates"] = bool(enabled)
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_email_updates_toggled",
-                    {"ticket_id": ticket_id, "enabled": bool(enabled)},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        with self._mutate_lock:
+            tickets = self._load()
+            updated = None
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket["email_updates"] = bool(enabled)
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                updated = ticket
+                break
+        if updated is None:
+            return None
+        try:
+            self.notifications.log_site_change(
+                actor_email or "unknown",
+                "ticket_email_updates_toggled",
+                {"ticket_id": ticket_id, "enabled": bool(enabled)},
+            )
+        except Exception:
+            pass
+        return updated
 
     # Send the email when ``email_updates`` is on AND we actually have a
     # reachable submitter address. The NotificationService itself will no-op
@@ -236,121 +249,133 @@ class TicketService:
         updates: dict,
         actor_email: str,
     ) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
+        with self._mutate_lock:
+            tickets = self._load()
+            target = None
             changed: dict = {}
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                target = ticket
 
-            if "status" in updates:
-                status = (updates.get("status") or "").strip().lower()
-                if status in ALLOWED_STATUSES and status != ticket.get("status"):
-                    ticket["status"] = status
-                    changed["status"] = status
+                if "status" in updates:
+                    status = (updates.get("status") or "").strip().lower()
+                    if status in ALLOWED_STATUSES and status != ticket.get("status"):
+                        ticket["status"] = status
+                        changed["status"] = status
 
-            if "priority" in updates:
-                priority = (updates.get("priority") or "").strip().lower()
-                if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
-                    ticket["priority"] = priority
-                    changed["priority"] = priority
+                if "priority" in updates:
+                    priority = (updates.get("priority") or "").strip().lower()
+                    if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
+                        ticket["priority"] = priority
+                        changed["priority"] = priority
 
-            if "assigned_to" in updates:
-                assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
-                if assignee != ticket.get("assigned_to"):
-                    ticket["assigned_to"] = assignee
-                    changed["assigned_to"] = assignee
+                if "assigned_to" in updates:
+                    assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
+                    if assignee != ticket.get("assigned_to"):
+                        ticket["assigned_to"] = assignee
+                        changed["assigned_to"] = assignee
 
+                if changed:
+                    ticket["updated_at"] = _now_iso()
+                    self._save(tickets)
+                break
+
+            if target is None:
+                return None
             if not changed:
-                return ticket
+                return target
 
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
-
-            # Email the submitter a summary of what changed.
-            friendly_bits = []
-            if "status" in changed:
-                friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
-            if "priority" in changed:
-                friendly_bits.append(f"Severity: {changed['priority']}")
-            if "assigned_to" in changed:
-                friendly_bits.append(
-                    f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
-                )
-            self._maybe_email_submitter(
-                ticket,
-                subject=f"Repair ticket update: {ticket.get('title', '')}",
-                body=(
-                    f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                    f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
-                    + "\n".join(friendly_bits)
-                    + "\n\nYou can view the full ticket in the Somewheria portal."
-                ),
+        # Email the submitter a summary of what changed.
+        friendly_bits = []
+        if "status" in changed:
+            friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
+        if "priority" in changed:
+            friendly_bits.append(f"Severity: {changed['priority']}")
+        if "assigned_to" in changed:
+            friendly_bits.append(
+                f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
             )
+        self._maybe_email_submitter(
+            target,
+            subject=f"Repair ticket update: {target.get('title', '')}",
+            body=(
+                f"Hi {target.get('submitter_name') or 'there'},\n\n"
+                f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
+                + "\n".join(friendly_bits)
+                + "\n\nYou can view the full ticket in the Somewheria portal."
+            ),
+        )
 
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_updated",
-                    {"ticket_id": ticket_id, **changed},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor_email or "unknown",
+                "ticket_updated",
+                {"ticket_id": ticket_id, **changed},
+            )
+        except Exception:
+            pass
+        return target
 
     def add_note(self, ticket_id: str, text: str, actor_email: str) -> dict | None:
         text = (text or "").strip()[:MAX_NOTE_LEN]
         if not text:
             raise ValueError("Note cannot be empty.")
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            actor = (actor_email or "unknown").lower()
-            ticket.setdefault("notes", []).append({
-                "at": _now_iso(),
-                "by": actor,
-                "text": text,
-            })
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
+        actor = (actor_email or "unknown").lower()
+        with self._mutate_lock:
+            tickets = self._load()
+            target = None
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket.setdefault("notes", []).append({
+                    "at": _now_iso(),
+                    "by": actor,
+                    "text": text,
+                })
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                target = ticket
+                break
 
-            submitter = (ticket.get("submitted_by") or "").lower()
-            if actor != submitter:
-                # Note from someone other than the submitter (typically admin);
-                # send a heads-up email if the submitter opted in.
-                self._maybe_email_submitter(
-                    ticket,
-                    subject=f"New note on your repair ticket: {ticket.get('title', '')}",
-                    body=(
-                        f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                        f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
-                        f"{text}\n\n"
-                        f"Reply from the ticket page in the Somewheria portal."
+        if target is None:
+            return None
+        ticket = target
+        submitter = (ticket.get("submitted_by") or "").lower()
+        if actor != submitter:
+            # Note from someone other than the submitter (typically admin);
+            # send a heads-up email if the submitter opted in.
+            self._maybe_email_submitter(
+                ticket,
+                subject=f"New note on your repair ticket: {ticket.get('title', '')}",
+                body=(
+                    f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
+                    f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
+                    f"{text}\n\n"
+                    f"Reply from the ticket page in the Somewheria portal."
+                ),
+            )
+        else:
+            # Note from the submitter — notify the internal inbox so staff
+            # see a renter reply even if they're not watching the dashboard.
+            try:
+                self.notifications.send_email(
+                    f"Renter note on ticket: {ticket.get('title', '')}",
+                    (
+                        f"Ticket: {ticket_id[:8]}\n"
+                        f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
+                        f"{text}"
                     ),
                 )
-            else:
-                # Note from the submitter — notify the internal inbox so staff
-                # see a renter reply even if they're not watching the dashboard.
-                try:
-                    self.notifications.send_email(
-                        f"Renter note on ticket: {ticket.get('title', '')}",
-                        (
-                            f"Ticket: {ticket_id[:8]}\n"
-                            f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
-                            f"{text}"
-                        ),
-                    )
-                except Exception as exc:
-                    self.logger.warning("Failed to forward renter note: %s", exc)
+            except Exception as exc:
+                self.logger.warning("Failed to forward renter note: %s", exc)
 
-            try:
-                self.notifications.log_site_change(
-                    actor,
-                    "ticket_note_added",
-                    {"ticket_id": ticket_id},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor,
+                "ticket_note_added",
+                {"ticket_id": ticket_id},
+            )
+        except Exception:
+            pass
+        return ticket

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -391,6 +391,12 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         set_role_mock.assert_called_once_with("pending@example.com", "renter")
         remove_pending_mock.assert_called_once_with("pending@example.com")
         send_email_mock.assert_called_once()
+        # The approval message must be sent to the applicant, not the admin
+        # inbox fallback used when ``to=`` is omitted.
+        self.assertEqual(
+            send_email_mock.call_args.kwargs.get("to"),
+            "pending@example.com",
+        )
 
     def test_admin_registrations_reject_calls_storage_and_email(self):
         self.login_as("admin")
@@ -413,6 +419,12 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         remove_pending_mock.assert_called_once_with("pending@example.com")
         send_email_mock.assert_called_once()
+        # The rejection message must be sent to the applicant, not the admin
+        # inbox fallback used when ``to=`` is omitted.
+        self.assertEqual(
+            send_email_mock.call_args.kwargs.get("to"),
+            "pending@example.com",
+        )
 
     def test_admin_users_page_loads(self):
         self.login_as("admin")


### PR DESCRIPTION
## Summary

Two backend fixes turned up while surveying the `somewheria_app/` package:

- **Registration approval/rejection emails went to the admin, not the applicant.**
  `admin_registrations` called `notifications.send_email(...)` with no `to=`.
  `NotificationService.send_email` falls back to `config.email_recipient`
  (the admin inbox) when `to` is omitted, so the message body
  "Your registration for Somewheria has been approved..." never reached
  the user. Fixed by passing `to=email`. Both existing tests now also
  assert the recipient.

- **`TicketService` had a load → mutate → save race.** The underlying
  `FileStorageService.file_lock` only covers a single read or write,
  so two concurrent ticket submissions could each load the same list,
  append, and one would overwrite the other on save. Same pattern in
  `update_ticket`, `set_email_updates`, and `add_note`. Added a
  service-level `RLock` and wrapped each load → mutate → save block,
  keeping email/log side effects outside the critical section.

No template, HTML, or schema changes; behavior unchanged on the happy
path.

## Test plan

- [x] `pytest` — 587 passed, 1 skipped (locally)
- [ ] CI green on PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01RczqsBAbce4UGWfiKfpLUy)_