### PR TITLE
Fix lost-update race in storage and ticket service mutations

### DIFF
--- a/somewheria_app/services/storage.py
+++ b/somewheria_app/services/storage.py
@@ -9,7 +9,10 @@ from .console import get_console_logger
 class FileStorageService:
     def __init__(self, config) -> None:
         self.config = config
-        self.file_lock = threading.Lock()
+        # Reentrant so a caller can hold the lock across an atomic
+        # read-modify-write while load_json_file/save_json_file (which also
+        # acquire it) run inside that block.
+        self.file_lock = threading.RLock()
         self.logger = get_console_logger("storage")
 
     def load_json_file(self, path, default, *, expected_type: type | tuple[type, ...] | None = None):
@@ -61,33 +64,39 @@ class FileStorageService:
         return self.load_json_file(self.config.registration_file, [], expected_type=list)
 
     def add_pending_registration(self, registration: dict) -> None:
-        registrations = self.get_pending_registrations()
-        registrations.append(registration)
-        self.save_json_file(self.config.registration_file, registrations)
+        # Atomic RMW: hold the file lock across load + save so a concurrent
+        # caller can't read the same baseline and clobber our append.
+        with self.file_lock:
+            registrations = self.get_pending_registrations()
+            registrations.append(registration)
+            self.save_json_file(self.config.registration_file, registrations)
 
     def remove_pending_registration(self, email: str) -> None:
-        registrations = [
-            item for item in self.get_pending_registrations() if item.get("email", "").lower() != email.lower()
-        ]
-        self.save_json_file(self.config.registration_file, registrations)
+        with self.file_lock:
+            registrations = [
+                item for item in self.get_pending_registrations() if item.get("email", "").lower() != email.lower()
+            ]
+            self.save_json_file(self.config.registration_file, registrations)
 
     def get_user_roles(self) -> dict:
         return self.load_json_file(self.config.user_roles_file, {}, expected_type=dict)
 
     def set_user_role(self, email: str, role: str) -> None:
-        roles = self.get_user_roles()
-        roles[email.lower()] = role
-        self.save_json_file(self.config.user_roles_file, roles)
+        with self.file_lock:
+            roles = self.get_user_roles()
+            roles[email.lower()] = role
+            self.save_json_file(self.config.user_roles_file, roles)
 
     def delete_user_role(self, email: str) -> bool:
         email = email.lower()
-        roles = self.get_user_roles()
-        previous = roles.get(email)
-        # Store a tombstone ("revoked") instead of removing the key outright
-        # so that env-var fallbacks in AuthService.get_user_role cannot
-        # silently restore a deleted user's access on their next login.
-        roles[email] = "revoked"
-        self.save_json_file(self.config.user_roles_file, roles)
+        with self.file_lock:
+            roles = self.get_user_roles()
+            previous = roles.get(email)
+            # Store a tombstone ("revoked") instead of removing the key outright
+            # so that env-var fallbacks in AuthService.get_user_role cannot
+            # silently restore a deleted user's access on their next login.
+            roles[email] = "revoked"
+            self.save_json_file(self.config.user_roles_file, roles)
         return previous is not None and previous != "revoked"
 
     def get_renter_profiles(self) -> dict:

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -10,6 +10,7 @@ The service is intentionally small and synchronous — it mirrors the
 from __future__ import annotations
 
 import datetime
+import threading
 import uuid
 from typing import Iterable
 
@@ -57,6 +58,12 @@ class TicketService:
         self.storage = storage
         self.notifications = notifications
         self.logger = get_console_logger("tickets")
+        # Serializes read-modify-write on the tickets file across mutating
+        # operations (create_ticket, update_ticket, add_note,
+        # set_email_updates). Without this, two concurrent callers can both
+        # load the same baseline list and the second save() silently
+        # overwrites the first one's change.
+        self._mutation_lock = threading.RLock()
 
     # ------------------------------------------------------------------ I/O
 
@@ -149,9 +156,10 @@ class TicketService:
             "notes": [],
         }
 
-        tickets = self._load()
-        tickets.append(ticket)
-        self._save(tickets)
+        with self._mutation_lock:
+            tickets = self._load()
+            tickets.append(ticket)
+            self._save(tickets)
 
         try:
             # Notify the internal admin inbox.
@@ -198,23 +206,28 @@ class TicketService:
         return ticket
 
     def set_email_updates(self, ticket_id: str, enabled: bool, actor_email: str) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            ticket["email_updates"] = bool(enabled)
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_email_updates_toggled",
-                    {"ticket_id": ticket_id, "enabled": bool(enabled)},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        updated: dict | None = None
+        with self._mutation_lock:
+            tickets = self._load()
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket["email_updates"] = bool(enabled)
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                updated = ticket
+                break
+        if updated is None:
+            return None
+        try:
+            self.notifications.log_site_change(
+                actor_email or "unknown",
+                "ticket_email_updates_toggled",
+                {"ticket_id": ticket_id, "enabled": bool(enabled)},
+            )
+        except Exception:
+            pass
+        return updated
 
     # Send the email when ``email_updates`` is on AND we actually have a
     # reachable submitter address. The NotificationService itself will no-op
@@ -236,121 +249,131 @@ class TicketService:
         updates: dict,
         actor_email: str,
     ) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            changed: dict = {}
+        updated: dict | None = None
+        changed: dict = {}
+        with self._mutation_lock:
+            tickets = self._load()
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
 
-            if "status" in updates:
-                status = (updates.get("status") or "").strip().lower()
-                if status in ALLOWED_STATUSES and status != ticket.get("status"):
-                    ticket["status"] = status
-                    changed["status"] = status
+                if "status" in updates:
+                    status = (updates.get("status") or "").strip().lower()
+                    if status in ALLOWED_STATUSES and status != ticket.get("status"):
+                        ticket["status"] = status
+                        changed["status"] = status
 
-            if "priority" in updates:
-                priority = (updates.get("priority") or "").strip().lower()
-                if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
-                    ticket["priority"] = priority
-                    changed["priority"] = priority
+                if "priority" in updates:
+                    priority = (updates.get("priority") or "").strip().lower()
+                    if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
+                        ticket["priority"] = priority
+                        changed["priority"] = priority
 
-            if "assigned_to" in updates:
-                assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
-                if assignee != ticket.get("assigned_to"):
-                    ticket["assigned_to"] = assignee
-                    changed["assigned_to"] = assignee
+                if "assigned_to" in updates:
+                    assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
+                    if assignee != ticket.get("assigned_to"):
+                        ticket["assigned_to"] = assignee
+                        changed["assigned_to"] = assignee
 
-            if not changed:
-                return ticket
+                if not changed:
+                    return ticket
 
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                updated = ticket
+                break
+        if updated is None:
+            return None
 
-            # Email the submitter a summary of what changed.
-            friendly_bits = []
-            if "status" in changed:
-                friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
-            if "priority" in changed:
-                friendly_bits.append(f"Severity: {changed['priority']}")
-            if "assigned_to" in changed:
-                friendly_bits.append(
-                    f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
-                )
-            self._maybe_email_submitter(
-                ticket,
-                subject=f"Repair ticket update: {ticket.get('title', '')}",
-                body=(
-                    f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                    f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
-                    + "\n".join(friendly_bits)
-                    + "\n\nYou can view the full ticket in the Somewheria portal."
-                ),
+        # Email the submitter a summary of what changed.
+        friendly_bits = []
+        if "status" in changed:
+            friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
+        if "priority" in changed:
+            friendly_bits.append(f"Severity: {changed['priority']}")
+        if "assigned_to" in changed:
+            friendly_bits.append(
+                f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
             )
+        self._maybe_email_submitter(
+            updated,
+            subject=f"Repair ticket update: {updated.get('title', '')}",
+            body=(
+                f"Hi {updated.get('submitter_name') or 'there'},\n\n"
+                f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
+                + "\n".join(friendly_bits)
+                + "\n\nYou can view the full ticket in the Somewheria portal."
+            ),
+        )
 
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_updated",
-                    {"ticket_id": ticket_id, **changed},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor_email or "unknown",
+                "ticket_updated",
+                {"ticket_id": ticket_id, **changed},
+            )
+        except Exception:
+            pass
+        return updated
 
     def add_note(self, ticket_id: str, text: str, actor_email: str) -> dict | None:
         text = (text or "").strip()[:MAX_NOTE_LEN]
         if not text:
             raise ValueError("Note cannot be empty.")
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            actor = (actor_email or "unknown").lower()
-            ticket.setdefault("notes", []).append({
-                "at": _now_iso(),
-                "by": actor,
-                "text": text,
-            })
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
+        actor = (actor_email or "unknown").lower()
+        updated: dict | None = None
+        with self._mutation_lock:
+            tickets = self._load()
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket.setdefault("notes", []).append({
+                    "at": _now_iso(),
+                    "by": actor,
+                    "text": text,
+                })
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                updated = ticket
+                break
+        if updated is None:
+            return None
 
-            submitter = (ticket.get("submitted_by") or "").lower()
-            if actor != submitter:
-                # Note from someone other than the submitter (typically admin);
-                # send a heads-up email if the submitter opted in.
-                self._maybe_email_submitter(
-                    ticket,
-                    subject=f"New note on your repair ticket: {ticket.get('title', '')}",
-                    body=(
-                        f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                        f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
-                        f"{text}\n\n"
-                        f"Reply from the ticket page in the Somewheria portal."
+        submitter = (updated.get("submitted_by") or "").lower()
+        if actor != submitter:
+            # Note from someone other than the submitter (typically admin);
+            # send a heads-up email if the submitter opted in.
+            self._maybe_email_submitter(
+                updated,
+                subject=f"New note on your repair ticket: {updated.get('title', '')}",
+                body=(
+                    f"Hi {updated.get('submitter_name') or 'there'},\n\n"
+                    f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
+                    f"{text}\n\n"
+                    f"Reply from the ticket page in the Somewheria portal."
+                ),
+            )
+        else:
+            # Note from the submitter — notify the internal inbox so staff
+            # see a renter reply even if they're not watching the dashboard.
+            try:
+                self.notifications.send_email(
+                    f"Renter note on ticket: {updated.get('title', '')}",
+                    (
+                        f"Ticket: {ticket_id[:8]}\n"
+                        f"From: {updated.get('submitter_name') or submitter or 'renter'}\n\n"
+                        f"{text}"
                     ),
                 )
-            else:
-                # Note from the submitter — notify the internal inbox so staff
-                # see a renter reply even if they're not watching the dashboard.
-                try:
-                    self.notifications.send_email(
-                        f"Renter note on ticket: {ticket.get('title', '')}",
-                        (
-                            f"Ticket: {ticket_id[:8]}\n"
-                            f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
-                            f"{text}"
-                        ),
-                    )
-                except Exception as exc:
-                    self.logger.warning("Failed to forward renter note: %s", exc)
+            except Exception as exc:
+                self.logger.warning("Failed to forward renter note: %s", exc)
 
-            try:
-                self.notifications.log_site_change(
-                    actor,
-                    "ticket_note_added",
-                    {"ticket_id": ticket_id},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor,
+                "ticket_note_added",
+                {"ticket_id": ticket_id},
+            )
+        except Exception:
+            pass
+        return updated

--- a/test_services.py
+++ b/test_services.py
@@ -849,5 +849,109 @@ class RateLimiterTestCase(unittest.TestCase):
         self.assertIn("active", limiter._hits)
 
 
+class ConcurrentMutationTestCase(unittest.TestCase):
+    """Lost-update regression coverage.
+
+    Storage and TicketService used to do load -> mutate -> save with the
+    file lock released between the load and the save, which let two
+    concurrent callers read the same baseline and clobber each other.
+    These tests assert that simultaneous mutations now all land.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.base = Path(self.tmpdir.name)
+        self.config = SimpleNamespace(
+            registration_file=self.base / "registrations.json",
+            user_roles_file=self.base / "roles.json",
+            renter_profile_file=self.base / "profiles.json",
+            contracts_file=self.base / "contracts.json",
+            tickets_file=self.base / "tickets.json",
+        )
+        self.storage = FileStorageService(self.config)
+
+    def _run_concurrently(self, fn, count=20):
+        import threading
+
+        barrier = threading.Barrier(count)
+        threads = []
+
+        def runner(i):
+            barrier.wait()  # release all threads as close to simultaneously as we can
+            fn(i)
+
+        for i in range(count):
+            t = threading.Thread(target=runner, args=(i,))
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+
+    def test_concurrent_set_user_role_does_not_lose_writes(self):
+        def assign(i):
+            self.storage.set_user_role(f"user{i}@example.com", "renter")
+
+        self._run_concurrently(assign, count=25)
+
+        roles = self.storage.get_user_roles()
+        self.assertEqual(len(roles), 25)
+        for i in range(25):
+            self.assertEqual(roles.get(f"user{i}@example.com"), "renter")
+
+    def test_concurrent_add_pending_registration_preserves_all(self):
+        def add(i):
+            self.storage.add_pending_registration({"email": f"a{i}@x", "name": str(i)})
+
+        self._run_concurrently(add, count=20)
+
+        pending = self.storage.get_pending_registrations()
+        self.assertEqual(len(pending), 20)
+        seen = {item["email"] for item in pending}
+        self.assertEqual(seen, {f"a{i}@x" for i in range(20)})
+
+    def test_concurrent_create_ticket_preserves_all(self):
+        from somewheria_app.services.tickets import TicketService
+
+        notifications = Mock()
+        # send_email/log_site_change are best-effort and shouldn't matter here.
+        service = TicketService(self.config, self.storage, notifications)
+
+        def create(i):
+            service.create_ticket(
+                {"title": f"T{i}", "description": f"D{i}"},
+                f"renter{i}@example.com",
+            )
+
+        self._run_concurrently(create, count=20)
+
+        # Use the service's own _load to read the persisted tickets.
+        all_tickets = service._load()
+        self.assertEqual(len(all_tickets), 20)
+        titles = {t["title"] for t in all_tickets}
+        self.assertEqual(titles, {f"T{i}" for i in range(20)})
+
+    def test_concurrent_add_note_preserves_all(self):
+        from somewheria_app.services.tickets import TicketService
+
+        notifications = Mock()
+        service = TicketService(self.config, self.storage, notifications)
+        ticket = service.create_ticket(
+            {"title": "Heater", "description": "broken"},
+            "renter@example.com",
+        )
+        ticket_id = ticket["id"]
+
+        def add_note(i):
+            service.add_note(ticket_id, f"note-{i}", "renter@example.com")
+
+        self._run_concurrently(add_note, count=15)
+
+        notes = service.get_ticket(ticket_id)["notes"]
+        self.assertEqual(len(notes), 15)
+        texts = {n["text"] for n in notes}
+        self.assertEqual(texts, {f"note-{i}" for i in range(15)})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`FileStorageService.file_lock` only protected individual `load_json_file` / `save_json_file` calls — not the read-modify-write pairs built on top of them. Two simultaneous callers running `load → mutate → save` could both read the same baseline and silently overwrite each other. The same pattern exists in `TicketService.create_ticket`, `update_ticket`, `add_note`, and `set_email_updates`.

New regression tests demonstrate the bug: without the fix, ~25–50% of writes are lost under contention (e.g., `set_user_role` x25 → only 16 land; `create_ticket` x20 → only 11 land).

## Changes

- **`somewheria_app/services/storage.py`**: switch `file_lock` from `threading.Lock` to `threading.RLock` so callers can hold it across an RMW block while the existing `load_json_file` / `save_json_file` (which also acquire it) run inside. Wrap `add_pending_registration`, `remove_pending_registration`, `set_user_role`, and `delete_user_role` in `with self.file_lock:` blocks.
- **`somewheria_app/services/tickets.py`**: add a service-level `_mutation_lock` (`RLock`) and wrap the four mutating methods so the load+save pair is atomic. Email/notification side-effects run *after* the lock is released so SMTP latency doesn't block other writers.
- **`test_services.py`**: add `ConcurrentMutationTestCase` with 4 tests that fire 15–25 threads at the same barrier and assert every write lands.

## Test plan

- [x] Full suite green locally (`pytest -q` → 591 passed, 1 skipped).
- [x] New tests pass with the fix and fail without it (verified by reverting source and re-running).
- [ ] CI green on PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcZZZr6mYith1NQ91RLB2P)_