### PR TITLE
Add SMTP timeout so stalled relay can't hang request workers

### DIFF
--- a/somewheria_app/services/notifications.py
+++ b/somewheria_app/services/notifications.py
@@ -9,6 +9,13 @@ from email.message import EmailMessage
 from .console import get_console_logger
 
 
+# Socket timeout (seconds) for every SMTP operation: connect, STARTTLS, login,
+# send. Without this, a stalled Gmail relay would tie up the calling worker
+# indefinitely — and many request handlers call send_email synchronously,
+# so a hung SMTP socket equals a hung HTTP request.
+SMTP_TIMEOUT_SECONDS = 15
+
+
 class NotificationService:
     def __init__(self, config, analytics) -> None:
         self.config = config
@@ -34,7 +41,7 @@ class NotificationService:
         message.add_alternative(self._html_email_body(subject, body), subtype="html")
 
         try:
-            with smtplib.SMTP("smtp.gmail.com", 587) as server:
+            with smtplib.SMTP("smtp.gmail.com", 587, timeout=SMTP_TIMEOUT_SECONDS) as server:
                 server.starttls()
                 server.login(self.config.email_sender, app_password)
                 server.send_message(message)

--- a/test_services.py
+++ b/test_services.py
@@ -490,10 +490,20 @@ class NotificationServiceTestCase(unittest.TestCase):
 
         with patch.object(self.service, "_email_password", return_value="app-pass"), patch(
             "somewheria_app.services.notifications.smtplib.SMTP", return_value=smtp_context
-        ):
+        ) as smtp_mock:
             result = self.service.send_email("Test Subject", "Hello world")
 
         self.assertTrue(result)
+        # SMTP must be called with a finite timeout so a stalled relay can't
+        # tie up the calling request worker indefinitely.
+        smtp_call_kwargs = smtp_mock.call_args.kwargs
+        smtp_call_args = smtp_mock.call_args.args
+        timeout = smtp_call_kwargs.get("timeout")
+        if timeout is None and len(smtp_call_args) >= 3:
+            timeout = smtp_call_args[2]
+        self.assertIsNotNone(timeout, "smtplib.SMTP must be invoked with a timeout")
+        self.assertGreater(timeout, 0)
+        self.assertLessEqual(timeout, 60)
         smtp_instance.starttls.assert_called_once()
         smtp_instance.login.assert_called_once_with("sender@example.com", "app-pass")
         smtp_instance.send_message.assert_called_once()
@@ -504,6 +514,17 @@ class NotificationServiceTestCase(unittest.TestCase):
         self.assertIsNotNone(html_part)
         self.assertIsNotNone(text_part)
         self.assertIn("Somewheria LLC", html_part.get_content())
+
+    def test_send_email_returns_false_on_smtp_timeout(self):
+        # A network-level timeout from smtplib must be caught and reported as
+        # a clean False, not bubble up into the request handler.
+        with patch.object(self.service, "_email_password", return_value="app-pass"), patch(
+            "somewheria_app.services.notifications.smtplib.SMTP",
+            side_effect=TimeoutError("smtp connect timed out"),
+        ):
+            result = self.service.send_email("Test Subject", "Hello world")
+
+        self.assertFalse(result)
 
     def test_send_email_returns_false_on_smtp_failure(self):
         smtp_instance = Mock()


### PR DESCRIPTION
## Summary

`smtplib.SMTP("smtp.gmail.com", 587)` was being constructed with no `timeout`,
so the underlying socket would block forever on connect / STARTTLS / login /
send. Many request handlers call `send_email` synchronously — `login`,
`schedule_appointment`, `report_issue`, admin save/delete/upload/toggle-sale,
registration approve/reject, `notify_image_edit`, every `log_and_notify_error`
path. If Gmail's SMTP relay stalled or the network blackholed, every one of
those routes would tie up its Flask worker indefinitely.

This sets a 15-second socket timeout on the SMTP connection and adds a
regression test that asserts `smtplib.SMTP` is invoked with a finite timeout
and that a `TimeoutError` from the SMTP layer is caught cleanly (returns
`False`, never bubbles into the request handler).

## Changes

- `somewheria_app/services/notifications.py`: pass `timeout=SMTP_TIMEOUT_SECONDS` (15s) to `smtplib.SMTP(...)`.
- `test_services.py`: extend `test_send_email_returns_true_on_success` to assert a finite timeout, and add `test_send_email_returns_false_on_smtp_timeout`.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 pytest -q` → 588 passed, 1 skipped (was 587 passed before this PR; the new SMTP-timeout test is the +1).
- [x] No template/HTML changes; backend-only as scoped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6HhhqvCgrBjNBfx57AdTn)_