### PR TITLE
Fix CI workflow, registration email recipient, and ticket save race

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,16 +12,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest
 
-      - name: Run Flask in background
-        run: |
-          python app.py & 
-          sleep 5 # Wait for Flask to start
-
-      - name: Run Playwright Tests
-        run: pytest tests/  # This is where your codegen scripts go
+      - name: Run tests
+        env:
+          DISABLE_BACKGROUND_THREADS: "1"
+        run: pytest .

--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -389,15 +389,20 @@ def admin_registrations():
         if action == "approve":
             services.storage.set_user_role(email, "renter")
             services.storage.remove_pending_registration(email)
+            # Decision emails are addressed to the applicant. Without to=,
+            # NotificationService falls back to the admin inbox, so the
+            # applicant never hears back.
             services.notifications.send_email(
                 "Registration Approved",
                 "Your registration for Somewheria has been approved. You can now log in.",
+                to=email,
             )
         elif action == "reject":
             services.storage.remove_pending_registration(email)
             services.notifications.send_email(
                 "Registration Rejected",
                 "Your registration for Somewheria was not approved at this time.",
+                to=email,
             )
         else:
             return render_template(

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -10,6 +10,7 @@ The service is intentionally small and synchronous — it mirrors the
 from __future__ import annotations
 
 import datetime
+import threading
 import uuid
 from typing import Iterable
 
@@ -57,6 +58,12 @@ class TicketService:
         self.storage = storage
         self.notifications = notifications
         self.logger = get_console_logger("tickets")
+        # FileStorageService.file_lock only covers a single read or write,
+        # so two threads doing load -> mutate -> save would race and lose
+        # one update. This RLock makes each mutating block atomic at the
+        # service level. Reentrant so a future helper can call into another
+        # mutating method without self-deadlock.
+        self._mutation_lock = threading.RLock()
 
     # ------------------------------------------------------------------ I/O
 
@@ -149,9 +156,10 @@ class TicketService:
             "notes": [],
         }
 
-        tickets = self._load()
-        tickets.append(ticket)
-        self._save(tickets)
+        with self._mutation_lock:
+            tickets = self._load()
+            tickets.append(ticket)
+            self._save(tickets)
 
         try:
             # Notify the internal admin inbox.
@@ -198,23 +206,28 @@ class TicketService:
         return ticket
 
     def set_email_updates(self, ticket_id: str, enabled: bool, actor_email: str) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            ticket["email_updates"] = bool(enabled)
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_email_updates_toggled",
-                    {"ticket_id": ticket_id, "enabled": bool(enabled)},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        with self._mutation_lock:
+            tickets = self._load()
+            updated_ticket: dict | None = None
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket["email_updates"] = bool(enabled)
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                updated_ticket = ticket
+                break
+        if updated_ticket is None:
+            return None
+        try:
+            self.notifications.log_site_change(
+                actor_email or "unknown",
+                "ticket_email_updates_toggled",
+                {"ticket_id": ticket_id, "enabled": bool(enabled)},
+            )
+        except Exception:
+            pass
+        return updated_ticket
 
     # Send the email when ``email_updates`` is on AND we actually have a
     # reachable submitter address. The NotificationService itself will no-op
@@ -236,121 +249,133 @@ class TicketService:
         updates: dict,
         actor_email: str,
     ) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
+        with self._mutation_lock:
+            tickets = self._load()
+            updated_ticket: dict | None = None
             changed: dict = {}
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
 
-            if "status" in updates:
-                status = (updates.get("status") or "").strip().lower()
-                if status in ALLOWED_STATUSES and status != ticket.get("status"):
-                    ticket["status"] = status
-                    changed["status"] = status
+                if "status" in updates:
+                    status = (updates.get("status") or "").strip().lower()
+                    if status in ALLOWED_STATUSES and status != ticket.get("status"):
+                        ticket["status"] = status
+                        changed["status"] = status
 
-            if "priority" in updates:
-                priority = (updates.get("priority") or "").strip().lower()
-                if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
-                    ticket["priority"] = priority
-                    changed["priority"] = priority
+                if "priority" in updates:
+                    priority = (updates.get("priority") or "").strip().lower()
+                    if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
+                        ticket["priority"] = priority
+                        changed["priority"] = priority
 
-            if "assigned_to" in updates:
-                assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
-                if assignee != ticket.get("assigned_to"):
-                    ticket["assigned_to"] = assignee
-                    changed["assigned_to"] = assignee
+                if "assigned_to" in updates:
+                    assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
+                    if assignee != ticket.get("assigned_to"):
+                        ticket["assigned_to"] = assignee
+                        changed["assigned_to"] = assignee
 
-            if not changed:
-                return ticket
+                if changed:
+                    ticket["updated_at"] = _now_iso()
+                    self._save(tickets)
+                updated_ticket = ticket
+                break
 
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
+        if updated_ticket is None:
+            return None
+        if not changed:
+            return updated_ticket
 
-            # Email the submitter a summary of what changed.
-            friendly_bits = []
-            if "status" in changed:
-                friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
-            if "priority" in changed:
-                friendly_bits.append(f"Severity: {changed['priority']}")
-            if "assigned_to" in changed:
-                friendly_bits.append(
-                    f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
-                )
-            self._maybe_email_submitter(
-                ticket,
-                subject=f"Repair ticket update: {ticket.get('title', '')}",
-                body=(
-                    f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                    f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
-                    + "\n".join(friendly_bits)
-                    + "\n\nYou can view the full ticket in the Somewheria portal."
-                ),
+        # Email the submitter a summary of what changed.
+        friendly_bits = []
+        if "status" in changed:
+            friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
+        if "priority" in changed:
+            friendly_bits.append(f"Severity: {changed['priority']}")
+        if "assigned_to" in changed:
+            friendly_bits.append(
+                f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
             )
+        self._maybe_email_submitter(
+            updated_ticket,
+            subject=f"Repair ticket update: {updated_ticket.get('title', '')}",
+            body=(
+                f"Hi {updated_ticket.get('submitter_name') or 'there'},\n\n"
+                f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
+                + "\n".join(friendly_bits)
+                + "\n\nYou can view the full ticket in the Somewheria portal."
+            ),
+        )
 
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_updated",
-                    {"ticket_id": ticket_id, **changed},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor_email or "unknown",
+                "ticket_updated",
+                {"ticket_id": ticket_id, **changed},
+            )
+        except Exception:
+            pass
+        return updated_ticket
 
     def add_note(self, ticket_id: str, text: str, actor_email: str) -> dict | None:
         text = (text or "").strip()[:MAX_NOTE_LEN]
         if not text:
             raise ValueError("Note cannot be empty.")
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            actor = (actor_email or "unknown").lower()
-            ticket.setdefault("notes", []).append({
-                "at": _now_iso(),
-                "by": actor,
-                "text": text,
-            })
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
+        actor = (actor_email or "unknown").lower()
 
-            submitter = (ticket.get("submitted_by") or "").lower()
-            if actor != submitter:
-                # Note from someone other than the submitter (typically admin);
-                # send a heads-up email if the submitter opted in.
-                self._maybe_email_submitter(
-                    ticket,
-                    subject=f"New note on your repair ticket: {ticket.get('title', '')}",
-                    body=(
-                        f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                        f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
-                        f"{text}\n\n"
-                        f"Reply from the ticket page in the Somewheria portal."
+        with self._mutation_lock:
+            tickets = self._load()
+            updated_ticket: dict | None = None
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket.setdefault("notes", []).append({
+                    "at": _now_iso(),
+                    "by": actor,
+                    "text": text,
+                })
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                updated_ticket = ticket
+                break
+        if updated_ticket is None:
+            return None
+
+        submitter = (updated_ticket.get("submitted_by") or "").lower()
+        if actor != submitter:
+            # Note from someone other than the submitter (typically admin);
+            # send a heads-up email if the submitter opted in.
+            self._maybe_email_submitter(
+                updated_ticket,
+                subject=f"New note on your repair ticket: {updated_ticket.get('title', '')}",
+                body=(
+                    f"Hi {updated_ticket.get('submitter_name') or 'there'},\n\n"
+                    f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
+                    f"{text}\n\n"
+                    f"Reply from the ticket page in the Somewheria portal."
+                ),
+            )
+        else:
+            # Note from the submitter — notify the internal inbox so staff
+            # see a renter reply even if they're not watching the dashboard.
+            try:
+                self.notifications.send_email(
+                    f"Renter note on ticket: {updated_ticket.get('title', '')}",
+                    (
+                        f"Ticket: {ticket_id[:8]}\n"
+                        f"From: {updated_ticket.get('submitter_name') or submitter or 'renter'}\n\n"
+                        f"{text}"
                     ),
                 )
-            else:
-                # Note from the submitter — notify the internal inbox so staff
-                # see a renter reply even if they're not watching the dashboard.
-                try:
-                    self.notifications.send_email(
-                        f"Renter note on ticket: {ticket.get('title', '')}",
-                        (
-                            f"Ticket: {ticket_id[:8]}\n"
-                            f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
-                            f"{text}"
-                        ),
-                    )
-                except Exception as exc:
-                    self.logger.warning("Failed to forward renter note: %s", exc)
+            except Exception as exc:
+                self.logger.warning("Failed to forward renter note: %s", exc)
 
-            try:
-                self.notifications.log_site_change(
-                    actor,
-                    "ticket_note_added",
-                    {"ticket_id": ticket_id},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor,
+                "ticket_note_added",
+                {"ticket_id": ticket_id},
+            )
+        except Exception:
+            pass
+        return updated_ticket

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -391,6 +391,8 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         set_role_mock.assert_called_once_with("pending@example.com", "renter")
         remove_pending_mock.assert_called_once_with("pending@example.com")
         send_email_mock.assert_called_once()
+        # The decision email must address the applicant, not the admin inbox.
+        self.assertEqual(send_email_mock.call_args.kwargs.get("to"), "pending@example.com")
 
     def test_admin_registrations_reject_calls_storage_and_email(self):
         self.login_as("admin")
@@ -413,6 +415,7 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         remove_pending_mock.assert_called_once_with("pending@example.com")
         send_email_mock.assert_called_once()
+        self.assertEqual(send_email_mock.call_args.kwargs.get("to"), "pending@example.com")
 
     def test_admin_users_page_loads(self):
         self.login_as("admin")

--- a/test_services.py
+++ b/test_services.py
@@ -11,6 +11,7 @@ from somewheria_app.services.auth import AuthService
 from somewheria_app.services.notifications import NotificationService
 from somewheria_app.services.properties import PropertyService
 from somewheria_app.services.storage import FileStorageService
+from somewheria_app.services.tickets import TicketService
 
 
 class DummyForm:
@@ -847,6 +848,61 @@ class RateLimiterTestCase(unittest.TestCase):
 
         self.assertNotIn("stale", limiter._hits)
         self.assertIn("active", limiter._hits)
+
+
+class TicketServiceConcurrencyTestCase(unittest.TestCase):
+    """Verify TicketService load -> mutate -> save blocks are atomic.
+
+    FileStorageService only locks individual reads or writes, so two
+    concurrent ticket submissions could each load the same list, append,
+    and have one save overwrite the other. The service-level lock added
+    in TicketService must serialize the whole block.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.config = SimpleNamespace(tickets_file=Path(self.tmpdir.name) / "tickets.json")
+        self.storage = FileStorageService(SimpleNamespace())
+        self.notifications = Mock()
+        # send_email returning truthy keeps the happy path in create_ticket.
+        self.notifications.send_email.return_value = True
+        self.service = TicketService(self.config, self.storage, self.notifications)
+
+    def test_concurrent_create_ticket_does_not_lose_writes(self):
+        import threading as _threading
+
+        N = 20
+        barrier = _threading.Barrier(N)
+        errors: list[BaseException] = []
+
+        def submit(i):
+            try:
+                barrier.wait(timeout=5)
+                self.service.create_ticket(
+                    {
+                        "title": f"t{i}",
+                        "description": f"d{i}",
+                        "category": "other",
+                        "priority": "normal",
+                    },
+                    submitter_email=f"r{i}@example.com",
+                )
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [_threading.Thread(target=submit, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        all_tickets = self.service.list_tickets()
+        self.assertEqual(len(all_tickets), N)
+        # IDs must be unique — i.e., no two threads produced a ticket that
+        # got dropped by an overwriting save.
+        self.assertEqual(len({t["id"] for t in all_tickets}), N)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three substantive backend fixes turned up while surveying `somewheria_app/`:

- **CI on `dev` is broken — every PR fails.** The merge from `main` into `dev` (commit 73a0d22) clobbered the working test job. The current workflow runs `python app.py` (file does not exist; the entrypoint is `website_app.py`) and then `pytest tests/` against a non-existent directory, with pytest itself never installed. PR #27 was lost to this. Restore a working job: install pytest, drop the dead "Run Flask in background" step (the suite uses Flask's test client, not a live server), and run `pytest .` against the root-level `test_*.py` files under `DISABLE_BACKGROUND_THREADS=1`.

- **Registration approve/reject emails went to the admin, not the applicant.** `admin_registrations` called `notifications.send_email(...)` with no `to=`. `NotificationService.send_email` falls back to `config.email_recipient` (the admin inbox) when `to` is omitted, so the message body "Your registration for Somewheria has been approved..." never reached the applicant. Fixed by passing `to=email`. Both existing tests now also assert the recipient.

- **`TicketService` had a load → mutate → save race on every mutating path** (`create_ticket`, `update_ticket`, `set_email_updates`, `add_note`). `FileStorageService.file_lock` only covers a single read or single write, so two concurrent ticket submissions could each load the same list, append, and one save would overwrite the other. Added a service-level `RLock`, wrapped each block, and moved email/log side effects out of the critical section. New regression test fires 20 concurrent `create_ticket` calls against a real `FileStorageService` and asserts every ticket survives.

No template / HTML / schema changes; behaviour unchanged on the happy path.

## Test plan

- [x] `pytest .` — 588 passed, 1 skipped (locally; +1 over dev for the new concurrency test)
- [ ] CI green on this PR (the workflow itself is part of the change)


---
_Generated by [Claude Code](https://claude.ai/code/session_018A4L5JfmagPgxy2MW6m3AM)_