### PR TITLE
Harden upstream payload validation & CSRF JSON token coercion

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -179,9 +179,18 @@ class PropertyService:
         try:
             response = requests.get(f"{self.config.api_base_url}/propertiesforrent", timeout=20)
             response.raise_for_status()
-            return response.json().get("property_ids", [])
+            payload = response.json()
         except Exception:
             return []
+        # A malformed upstream payload (string, list, dict-of-non-list, …) must
+        # not silently iterate as characters or unrelated keys downstream — that
+        # would spray the upstream API with junk per-id requests.
+        if not isinstance(payload, dict):
+            return []
+        ids = payload.get("property_ids", [])
+        if not isinstance(ids, list):
+            return []
+        return [item for item in ids if isinstance(item, str)]
 
     def fetch_property_record(self, property_id: str):
         # Defense in depth: refuse property IDs that don't match the expected

--- a/somewheria_app/services/security.py
+++ b/somewheria_app/services/security.py
@@ -39,7 +39,12 @@ def _extract_submitted_token() -> str:
     if request.is_json:
         payload = request.get_json(silent=True) or {}
         if isinstance(payload, dict):
-            token = payload.get(CSRF_FORM_FIELD, "") or ""
+            # Coerce non-string values (lists, numbers, dicts) to "" — passing
+            # them to secrets.compare_digest below would raise TypeError and
+            # turn a malformed CSRF body into a 500 instead of a clean 400.
+            candidate = payload.get(CSRF_FORM_FIELD, "")
+            if isinstance(candidate, str):
+                token = candidate
     return token or ""
 
 

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -196,6 +196,29 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
 
         self.assertEqual(property_ids, [])
 
+    def test_fetch_property_ids_rejects_non_dict_payload(self):
+        # A misbehaving upstream that returns a top-level list/string must not
+        # silently iterate as characters or unrelated keys downstream.
+        for bogus in (["prop-1", "prop-2"], "prop-1", 42, None):
+            response = Mock()
+            response.json.return_value = bogus
+            with patch("somewheria_app.services.properties.requests.get", return_value=response):
+                self.assertEqual(self.service._fetch_property_ids(), [])
+
+    def test_fetch_property_ids_rejects_non_list_property_ids_field(self):
+        response = Mock()
+        response.json.return_value = {"property_ids": "prop-1"}
+
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            self.assertEqual(self.service._fetch_property_ids(), [])
+
+    def test_fetch_property_ids_filters_out_non_string_entries(self):
+        response = Mock()
+        response.json.return_value = {"property_ids": ["prop-1", 42, None, "prop-2"]}
+
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            self.assertEqual(self.service._fetch_property_ids(), ["prop-1", "prop-2"])
+
     def test_fetch_property_record_builds_normalized_payload(self):
         details_response = Mock()
         details_response.json.return_value = {"name": "Maple House"}

--- a/test_services.py
+++ b/test_services.py
@@ -849,5 +849,57 @@ class RateLimiterTestCase(unittest.TestCase):
         self.assertIn("active", limiter._hits)
 
 
+class CsrfTokenExtractionTestCase(unittest.TestCase):
+    """``_extract_submitted_token`` must always return a string so the
+    ``secrets.compare_digest`` check in ``_csrf_before_request`` can never
+    raise TypeError on a malformed body — that would surface as a 500 instead
+    of the intended 400."""
+
+    def _build_app(self):
+        from flask import Flask
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        return app
+
+    def _extract(self, app, **request_kwargs):
+        from somewheria_app.services.security import _extract_submitted_token
+
+        with app.test_request_context(**request_kwargs):
+            return _extract_submitted_token()
+
+    def test_returns_string_for_header(self):
+        app = self._build_app()
+        token = self._extract(app, method="POST", headers={"X-CSRF-Token": "abc"})
+        self.assertEqual(token, "abc")
+
+    def test_returns_empty_when_nothing_submitted(self):
+        app = self._build_app()
+        self.assertEqual(self._extract(app, method="POST"), "")
+
+    def test_coerces_non_string_json_token_to_empty(self):
+        app = self._build_app()
+        # JSON body where _csrf_token is a list — passing this to
+        # secrets.compare_digest would raise TypeError. The extractor must
+        # treat it as missing instead.
+        for bogus in ([1, 2, 3], {"nested": "x"}, 42, None):
+            token = self._extract(
+                app,
+                method="POST",
+                json={"_csrf_token": bogus},
+            )
+            self.assertEqual(token, "", f"non-string token {bogus!r} should coerce to ''")
+            self.assertIsInstance(token, str)
+
+    def test_accepts_string_json_token(self):
+        app = self._build_app()
+        token = self._extract(
+            app,
+            method="POST",
+            json={"_csrf_token": "json-token"},
+        )
+        self.assertEqual(token, "json-token")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two small, defensive backend fixes found during today's maintenance survey.

- **`PropertyService._fetch_property_ids`** now rejects malformed upstream responses. Previously, if `/propertiesforrent` returned a top-level list/string or a `property_ids` field that wasn't a list, downstream code would iterate over characters / unrelated keys and spray junk per-id requests at the upstream API.
- **`security._extract_submitted_token`** only accepts `str` values for `_csrf_token` pulled out of a JSON body. A list / number / dict would have flowed into `secrets.compare_digest`, raising `TypeError` and surfacing as a 500 instead of the intended 400.

Both are isolated, additive guards with no behavior change on well-formed inputs.

## Test plan

- [x] `pytest` — 597 passed, 1 skipped (was 590 + 7 new tests for these cases).
- [x] New tests cover non-dict payloads, non-list `property_ids`, non-string entries, and non-string JSON CSRF token values.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFdoEis2b7XttzRrmoMani)_