### PR TITLE
Bring SqlStorageService to parity with FileStorageService

### DIFF
--- a/scripts/migrate_from_json.py
+++ b/scripts/migrate_from_json.py
@@ -46,6 +46,7 @@ def migrate(config: AppConfig, *, dry_run: bool = False) -> dict:
     profiles = _read_json(config.renter_profile_file, {})
     contracts = _read_json(config.contracts_file, {})
     tickets = _read_json(config.tickets_file, [])
+    leads = _read_json(config.lead_capture_file, [])
 
     counts = {
         "user_roles": len(roles) if isinstance(roles, dict) else 0,
@@ -55,6 +56,7 @@ def migrate(config: AppConfig, *, dry_run: bool = False) -> dict:
             len(v) for v in (contracts.values() if isinstance(contracts, dict) else [])
         ),
         "tickets": len(tickets) if isinstance(tickets, list) else 0,
+        "lead_captures": len(leads) if isinstance(leads, list) else 0,
     }
 
     if dry_run:
@@ -66,6 +68,7 @@ def migrate(config: AppConfig, *, dry_run: bool = False) -> dict:
     storage.save_renter_profiles(profiles if isinstance(profiles, dict) else {})
     storage.save_renter_contracts(contracts if isinstance(contracts, dict) else {})
     storage._save_tickets(tickets if isinstance(tickets, list) else [])
+    storage._replace_pending_lead_captures(leads if isinstance(leads, list) else [])
     return counts
 
 

--- a/somewheria_app/services/database.py
+++ b/somewheria_app/services/database.py
@@ -17,6 +17,7 @@ Schema overview
    contract TEXT NOT NULL, PRIMARY KEY (email, idx))``
 - ``tickets(id TEXT PRIMARY KEY, payload TEXT NOT NULL,
    updated_at TEXT, created_at TEXT)``
+- ``lead_captures(email TEXT PRIMARY KEY, payload TEXT NOT NULL)``
 
 Tickets and registrations keep their full dict in a JSON ``payload`` column to
 match the existing flexible shape; promotion to typed columns can come later
@@ -66,6 +67,12 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
         payload    TEXT NOT NULL,
         created_at TEXT,
         updated_at TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS lead_captures (
+        email   TEXT PRIMARY KEY,
+        payload TEXT NOT NULL
     )
     """,
 )

--- a/somewheria_app/services/sql_storage.py
+++ b/somewheria_app/services/sql_storage.py
@@ -15,6 +15,8 @@ as a routing key — ``config.tickets_file`` routes to the ``tickets`` table.
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 
 from .console import get_console_logger
@@ -41,6 +43,8 @@ class SqlStorageService:
             return "renter_contracts"
         if path == self.config.tickets_file:
             return "tickets"
+        if path == self.config.lead_capture_file:
+            return "lead_captures"
         return ""
 
     # ---------------- Generic JSON shim used by TicketService et al --------
@@ -61,6 +65,8 @@ class SqlStorageService:
                 return self.get_renter_profiles()
             if key == "renter_contracts":
                 return self.get_renter_contracts()
+            if key == "lead_captures":
+                return self.get_pending_lead_captures()
         except Exception as exc:  # pragma: no cover - defensive
             self.logger.error("Failed to load %s from sqlite: %s", path, exc)
         return default
@@ -81,6 +87,8 @@ class SqlStorageService:
                 self.save_renter_profiles(data)
             elif key == "renter_contracts":
                 self.save_renter_contracts(data)
+            elif key == "lead_captures":
+                self._replace_pending_lead_captures(data)
         except Exception as exc:  # pragma: no cover - defensive
             self.logger.error("Failed to save %s to sqlite: %s", path, exc)
 
@@ -218,3 +226,101 @@ class SqlStorageService:
                         ticket.get("updated_at"),
                     ),
                 )
+
+    # ----------------------------------------------------------- lead_captures
+
+    def get_pending_lead_captures(self) -> list[dict]:
+        with self.db.read() as conn:
+            rows = conn.execute(
+                "SELECT payload FROM lead_captures ORDER BY email"
+            ).fetchall()
+        return [loads(row["payload"]) for row in rows]
+
+    def add_pending_lead_capture(self, lead: dict) -> None:
+        # Mirror FileStorageService: de-duplicate by email so a repeated
+        # submission doesn't bloat the table or flood the admin UI.
+        target_email = (lead.get("email") or "").strip().lower()
+        if not target_email:
+            return
+        with self.db.transaction() as conn:
+            existing = conn.execute(
+                "SELECT 1 FROM lead_captures WHERE email = ?", (target_email,)
+            ).fetchone()
+            if existing is not None:
+                return
+            conn.execute(
+                "INSERT INTO lead_captures(email, payload) VALUES (?, ?)",
+                (target_email, dumps(lead)),
+            )
+
+    def remove_pending_lead_capture(self, email: str) -> None:
+        email_lc = (email or "").strip().lower()
+        if not email_lc:
+            return
+        with self.db.transaction() as conn:
+            conn.execute("DELETE FROM lead_captures WHERE email = ?", (email_lc,))
+
+    def _replace_pending_lead_captures(self, data: list[dict]) -> None:
+        with self.db.transaction() as conn:
+            conn.execute("DELETE FROM lead_captures")
+            for item in data or []:
+                email = (item.get("email") or "").strip().lower()
+                if not email:
+                    continue
+                conn.execute(
+                    "INSERT OR REPLACE INTO lead_captures(email, payload) VALUES (?, ?)",
+                    (email, dumps(item)),
+                )
+
+    # --------------------------------------------------------------- binaries
+    #
+    # Binary attachments (signed-contract PDFs at
+    # ``static/uploads/contracts/<uuid>.pdf`` and ticket photos at
+    # ``static/uploads/tickets/<ticket_id>/``) are URL-addressed from inside
+    # ticket / contract JSON payloads, so they continue to live on disk even
+    # when ``USE_SQLITE_STORAGE=1``. These mirror the implementation in
+    # ``FileStorageService`` (atomic temp-file + os.replace + fsync) so the
+    # request handlers don't need to know which backend is wired up.
+
+    def save_binary_file(self, path, data: bytes) -> bool:
+        """Persist ``data`` to ``path`` atomically. Returns True on success."""
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=path.name + ".", suffix=".tmp", dir=str(path.parent)
+            )
+            try:
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(data)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_name, path)
+            except Exception:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
+            return True
+        except Exception as exc:
+            self.logger.error("Failed to save binary file %s: %s", path, exc)
+            return False
+
+    def load_binary_file(self, path) -> bytes | None:
+        try:
+            if not path.exists():
+                return None
+            with path.open("rb") as handle:
+                return handle.read()
+        except Exception as exc:
+            self.logger.error("Failed to load binary file %s: %s", path, exc)
+            return None
+
+    def delete_file(self, path) -> bool:
+        try:
+            if path.exists():
+                os.unlink(path)
+                return True
+        except Exception as exc:
+            self.logger.error("Failed to delete file %s: %s", path, exc)
+        return False

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -1,0 +1,224 @@
+"""End-to-end tests for ``SqlStorageService``.
+
+These exercise the SQLite-backed storage backend that activates when
+``USE_SQLITE_STORAGE=1``. The scaffold landed without test coverage and
+subsequently fell behind ``FileStorageService`` (it was missing lead-capture
+and binary-file methods). These tests pin both the schema and the public
+API parity so the feature flag is safe to flip in production.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from somewheria_app.services.sql_storage import SqlStorageService
+
+
+def _make_config(base: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        registration_file=base / "pending_registrations.json",
+        user_roles_file=base / "user_roles.json",
+        renter_profile_file=base / "renter_profiles.json",
+        contracts_file=base / "renter_contracts.json",
+        tickets_file=base / "tickets.json",
+        lead_capture_file=base / "pending_lead_captures.json",
+        sqlite_file=base / "test.sqlite3",
+    )
+
+
+class SqlStorageBaseTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.base = Path(self._tmp.name)
+        self.config = _make_config(self.base)
+        self.storage = SqlStorageService(self.config)
+
+
+class UserRolesTestCase(SqlStorageBaseTestCase):
+    def test_set_and_get_role(self):
+        self.storage.set_user_role("Admin@Example.com", "admin")
+        roles = self.storage.get_user_roles()
+        self.assertEqual(roles, {"admin@example.com": "admin"})
+
+    def test_delete_user_role_records_tombstone(self):
+        self.storage.set_user_role("user@example.com", "renter")
+        existed = self.storage.delete_user_role("user@example.com")
+        self.assertTrue(existed)
+        # Tombstone "revoked" must persist so env-var fallbacks can't silently
+        # restore access. The role isn't removed outright.
+        self.assertEqual(
+            self.storage.get_user_roles(), {"user@example.com": "revoked"}
+        )
+
+    def test_delete_user_role_returns_false_when_absent(self):
+        existed = self.storage.delete_user_role("ghost@example.com")
+        self.assertFalse(existed)
+
+
+class PendingRegistrationsTestCase(SqlStorageBaseTestCase):
+    def test_add_and_get(self):
+        self.storage.add_pending_registration(
+            {"email": "Alice@Example.com", "name": "Alice"}
+        )
+        rows = self.storage.get_pending_registrations()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["email"], "Alice@Example.com")
+        self.assertEqual(rows[0]["name"], "Alice")
+
+    def test_remove_pending_registration(self):
+        self.storage.add_pending_registration({"email": "a@example.com"})
+        self.storage.add_pending_registration({"email": "b@example.com"})
+        self.storage.remove_pending_registration("A@Example.com")
+        rows = self.storage.get_pending_registrations()
+        self.assertEqual({r["email"] for r in rows}, {"b@example.com"})
+
+
+class RenterProfilesTestCase(SqlStorageBaseTestCase):
+    def test_save_and_get(self):
+        self.storage.save_renter_profiles(
+            {"renter@example.com": {"name": "Renter R"}}
+        )
+        profiles = self.storage.get_renter_profiles()
+        self.assertEqual(profiles, {"renter@example.com": {"name": "Renter R"}})
+
+
+class RenterContractsTestCase(SqlStorageBaseTestCase):
+    def test_save_and_get_preserves_order(self):
+        contracts = {
+            "renter@example.com": [
+                {"contract_id": "a"},
+                {"contract_id": "b"},
+                {"contract_id": "c"},
+            ]
+        }
+        self.storage.save_renter_contracts(contracts)
+        out = self.storage.get_renter_contracts()
+        self.assertEqual(
+            [c["contract_id"] for c in out["renter@example.com"]],
+            ["a", "b", "c"],
+        )
+
+
+class TicketsTestCase(SqlStorageBaseTestCase):
+    def test_save_and_load_via_path_shim(self):
+        # TicketService calls load_json_file / save_json_file directly with
+        # config.tickets_file. The shim must route to the tickets table.
+        tickets = [
+            {"id": "t1", "title": "leak", "created_at": "2026-01-01"},
+            {"id": "t2", "title": "lock", "created_at": "2026-01-02"},
+        ]
+        self.storage.save_json_file(self.config.tickets_file, tickets)
+        loaded = self.storage.load_json_file(self.config.tickets_file, [])
+        self.assertEqual(sorted(t["id"] for t in loaded), ["t1", "t2"])
+
+
+class LeadCapturesTestCase(SqlStorageBaseTestCase):
+    """Regression coverage for the lead-capture flow under SQLite."""
+
+    def test_add_pending_lead_capture(self):
+        self.storage.add_pending_lead_capture(
+            {"email": "lead@example.com", "submitted_at": "2026-01-01"}
+        )
+        leads = self.storage.get_pending_lead_captures()
+        self.assertEqual(len(leads), 1)
+        self.assertEqual(leads[0]["email"], "lead@example.com")
+        self.assertEqual(leads[0]["submitted_at"], "2026-01-01")
+
+    def test_add_pending_lead_capture_dedupes_existing_email(self):
+        # Mirror FileStorageService: repeated submissions don't bloat storage.
+        self.storage.add_pending_lead_capture(
+            {"email": "dup@example.com", "submitted_at": "2026-01-01"}
+        )
+        self.storage.add_pending_lead_capture(
+            {"email": "dup@example.com", "submitted_at": "2026-02-02"}
+        )
+        leads = self.storage.get_pending_lead_captures()
+        self.assertEqual(len(leads), 1)
+        self.assertEqual(leads[0]["submitted_at"], "2026-01-01")
+
+    def test_add_pending_lead_capture_dedupe_is_case_insensitive(self):
+        self.storage.add_pending_lead_capture({"email": "Mixed@Example.com"})
+        self.storage.add_pending_lead_capture({"email": "mixed@example.com"})
+        self.assertEqual(len(self.storage.get_pending_lead_captures()), 1)
+
+    def test_add_pending_lead_capture_ignores_missing_email(self):
+        self.storage.add_pending_lead_capture({"submitted_at": "2026-01-01"})
+        self.assertEqual(self.storage.get_pending_lead_captures(), [])
+
+    def test_remove_pending_lead_capture(self):
+        self.storage.add_pending_lead_capture({"email": "keep@example.com"})
+        self.storage.add_pending_lead_capture({"email": "drop@example.com"})
+        self.storage.remove_pending_lead_capture("DROP@Example.com")
+        leads = self.storage.get_pending_lead_captures()
+        self.assertEqual({lead["email"] for lead in leads}, {"keep@example.com"})
+
+    def test_remove_pending_lead_capture_no_op_on_empty_email(self):
+        self.storage.add_pending_lead_capture({"email": "keep@example.com"})
+        self.storage.remove_pending_lead_capture("")
+        self.assertEqual(len(self.storage.get_pending_lead_captures()), 1)
+
+    def test_load_via_path_shim(self):
+        # Public callers go through the shim with config.lead_capture_file.
+        self.storage.add_pending_lead_capture({"email": "lead@example.com"})
+        loaded = self.storage.load_json_file(self.config.lead_capture_file, [])
+        self.assertEqual([lead["email"] for lead in loaded], ["lead@example.com"])
+
+    def test_save_via_path_shim_replaces_table(self):
+        self.storage.add_pending_lead_capture({"email": "old@example.com"})
+        self.storage.save_json_file(
+            self.config.lead_capture_file,
+            [{"email": "new@example.com", "submitted_at": "2026-03-03"}],
+        )
+        loaded = self.storage.get_pending_lead_captures()
+        self.assertEqual([lead["email"] for lead in loaded], ["new@example.com"])
+
+
+class BinaryFileTestCase(SqlStorageBaseTestCase):
+    """Binary attachments stay on disk even under SQLite storage."""
+
+    def test_save_load_round_trip(self):
+        path = self.base / "uploads" / "contracts" / "abc.pdf"
+        ok = self.storage.save_binary_file(path, b"%PDF-1.4 fake")
+        self.assertTrue(ok)
+        self.assertEqual(self.storage.load_binary_file(path), b"%PDF-1.4 fake")
+
+    def test_save_creates_parent_directories(self):
+        # The contracts/tickets upload directories are pre-created at startup
+        # by AppConfig.ensure_directories, but each ticket gets its own
+        # subdirectory at upload time. mkdir(parents=True) is required.
+        path = self.base / "uploads" / "tickets" / "abc123" / "photo.jpg"
+        ok = self.storage.save_binary_file(path, b"\xff\xd8\xff\xe0")
+        self.assertTrue(ok)
+        self.assertTrue(path.exists())
+
+    def test_load_missing_returns_none(self):
+        self.assertIsNone(self.storage.load_binary_file(self.base / "nope.bin"))
+
+    def test_delete_file_removes_existing(self):
+        path = self.base / "delete_me.bin"
+        self.storage.save_binary_file(path, b"data")
+        self.assertTrue(self.storage.delete_file(path))
+        self.assertFalse(path.exists())
+
+    def test_delete_file_returns_false_when_absent(self):
+        self.assertFalse(self.storage.delete_file(self.base / "ghost.bin"))
+
+
+class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
+    """An unrecognised path must NOT silently corrupt or crash."""
+
+    def test_unknown_load_returns_default(self):
+        out = self.storage.load_json_file(self.base / "unknown.json", [])
+        self.assertEqual(out, [])
+
+    def test_unknown_save_is_a_no_op(self):
+        # Must not raise; the warning is logged but the request flow continues.
+        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The SQLite-backed storage scaffold (`USE_SQLITE_STORAGE=1`) landed before the lead-capture (§3.3) and ticket-photo / contract-PDF (§1.4 / renter portal) flows existed, and was never updated to match. With the flag enabled, real production traffic would hit `AttributeError` at runtime:

- `POST /lead-captures` → `services.storage.add_pending_lead_capture(...)` is missing on `SqlStorageService`.
- `/admin/lead-captures` (GET + approve/reject POST) → `get_pending_lead_captures` / `remove_pending_lead_capture` are missing.
- Ticket photo upload (`TicketService.add_photo`) → `save_binary_file` is missing.
- Contract PDF storage (admin signed-contract flow) → `save_binary_file` / `delete_file` are missing.

The gap went unnoticed because **`SqlStorageService` had zero test coverage** — `grep -n "SqlStorageService" test_*.py` returns nothing on `main`.

### What this PR changes

1. **Lead-capture support on the SQLite backend.** New `lead_captures(email TEXT PRIMARY KEY, payload TEXT NOT NULL)` table; `get_pending_lead_captures` / `add_pending_lead_capture` (case-insensitive dedup by email, matching `FileStorageService` semantics) / `remove_pending_lead_capture` / private `_replace_pending_lead_captures`; path-shim routing for `config.lead_capture_file`; one extra line in `scripts/migrate_from_json.py` so existing on-disk `pending_lead_captures.json` migrates cleanly.
2. **Binary file methods on the SQLite backend.** `save_binary_file` / `load_binary_file` / `delete_file` mirror the on-disk implementation in `FileStorageService` (atomic temp-file + `os.replace` + `fsync`). Binary attachments stay on disk under either backend — they're URL-addressed from inside ticket / contract JSON payloads and never lived in the database.
3. **New `test_sql_storage.py`** with 23 tests covering every public method of `SqlStorageService`: user roles + tombstones, pending registrations, renter profiles, renter contracts (preserves order), tickets via the path shim, lead-capture CRUD + dedup + case-insensitive matching + empty-email guards, binary save/load/delete + parent-directory creation, and the unknown-path shim guards.

## Test plan

- [x] `python -m unittest test_sql_storage` — 23/23 pass
- [x] `python -m unittest discover` — 676/676 pass (was 653, +23 new)
- [x] No changes to `FileStorageService` or to any caller — existing behaviour with `USE_SQLITE_STORAGE` unset (the default) is byte-identical.
- [x] Scope respects the daily-maintenance brief: backend only, no templates or HTML touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvxHdtZjHXSsKp7qrk5yHC)_