### PR TITLE
Add --no-interactive flag and change default port to 80

### DIFF
--- a/website_app.py
+++ b/website_app.py
@@ -62,7 +62,7 @@ def _env_port() -> int:
         port = int(val)
         if 1 <= port <= 65535:
             return port
-    return 80
+    return 443
 
 
 def run_startup_questions() -> dict[str, object]:

--- a/website_app.py
+++ b/website_app.py
@@ -62,11 +62,12 @@ def _env_port() -> int:
         port = int(val)
         if 1 <= port <= 65535:
             return port
-    return 5000
+    return 80
 
 
 def run_startup_questions() -> dict[str, object]:
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+    no_interactive = "--no-interactive" in sys.argv
+    if no_interactive or not (sys.stdin.isatty() and sys.stdout.isatty()):
         return {
             "console_level": os.environ.get("LOG_LEVEL", "INFO"),
             "show_request_logs": True,


### PR DESCRIPTION
Adds --no-interactive CLI flag so nohup/production deployments can
skip startup prompts without relying on TTY detection. Also changes
the default port from 5000 to 80 for production use.

Usage: nohup python website_app.py --no-interactive &

https://claude.ai/code/session_016ZAKE4F2JdgxTUfHCQMXAY