### PR TITLE
Fix CI: restore documented port-5000 default and clear ruff F401 warnings

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 import io
-import secrets
 import uuid as uuid_lib
 
 from flask import Response, abort, current_app, jsonify, redirect, render_template, request, send_file, url_for

--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -5,9 +5,7 @@ from flask import jsonify, render_template, request
 from ..services.auth import (
     get_current_user,
     high_admin_required,
-    is_logged_in,
     login_required,
-    renter_required,
 )
 from ..services.registry import get_services
 from ..services.security import rate_limit

--- a/somewheria_app/services/security.py
+++ b/somewheria_app/services/security.py
@@ -4,7 +4,7 @@ from collections import deque
 from functools import wraps
 from threading import Lock
 
-from flask import abort, current_app, g, jsonify, request, session
+from flask import abort, current_app, jsonify, request, session
 
 
 CSRF_SESSION_KEY = "_csrf_token"

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -3,8 +3,6 @@ import importlib
 import io
 import os
 import runpy
-import shutil
-import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace

--- a/website_app.py
+++ b/website_app.py
@@ -62,7 +62,12 @@ def _env_port() -> int:
         port = int(val)
         if 1 <= port <= 65535:
             return port
-    return 443
+    # Fallback when PORT is unset and there's no TTY (CI, tests, containers
+    # without an explicit PORT). Production deployments set PORT explicitly —
+    # start.sh does this for port 80 via authbind, and systemd units / Docker
+    # set PORT in the environment. 5000 is Flask's conventional dev default
+    # and is what docs/RUNBOOK.md and CLAUDE.md document.
+    return 5000
 
 
 def run_startup_questions() -> dict[str, object]:


### PR DESCRIPTION
## Summary

`main` was shipping with two pre-existing CI failures. Daily maintenance pass to restore green CI.

### 1. Port-5000 default regression

Commit `df5bfe4` changed the non-TTY fallback in `_env_port()` to **443**, but CLAUDE.md, `docs/RUNBOOK.md`, and two test cases (`test_startup.test_run_startup_questions_uses_defaults_when_non_interactive`, `test_coverage_full.test_main_block_runs_default_startup_path`) all document and assert **5000**. 443 is also a poor default — it requires elevated privileges, and production deployments set `PORT` explicitly (`start.sh` for port 80 via authbind; systemd / Docker env). Restored the fallback to 5000 so the code matches the docs and the tests pass again.

### 2. `ruff check .` failures (lint job)

Four unused imports were tripping the lint job:
- `somewheria_app/routes/admin_routes.py`: `secrets`
- `somewheria_app/routes/public_routes.py`: `is_logged_in`, `renter_required`
- `somewheria_app/services/security.py`: `flask.g`
- `test_coverage_full.py`: `shutil`, `tempfile`

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 FLASK_ENV=development SECRET_KEY=ci-only-not-for-prod python -m unittest discover` — 676 passed, 1 skipped (was 2 failing before)
- [x] `ruff check .` — clean (was 4 errors before)
- [ ] CI passes on both `test` and `lint` jobs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9vfDJyojeu7siXHzvXf33)_