### PR TITLE
Fix CI: drop unused imports and align startup tests with new port default

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 import io
-import secrets
 import uuid as uuid_lib
 
 from flask import Response, abort, current_app, jsonify, redirect, render_template, request, send_file, url_for

--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -5,9 +5,7 @@ from flask import jsonify, render_template, request
 from ..services.auth import (
     get_current_user,
     high_admin_required,
-    is_logged_in,
     login_required,
-    renter_required,
 )
 from ..services.registry import get_services
 from ..services.security import rate_limit

--- a/somewheria_app/services/security.py
+++ b/somewheria_app/services/security.py
@@ -4,7 +4,7 @@ from collections import deque
 from functools import wraps
 from threading import Lock
 
-from flask import abort, current_app, g, jsonify, request, session
+from flask import abort, current_app, jsonify, request, session
 
 
 CSRF_SESSION_KEY = "_csrf_token"

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -3,8 +3,6 @@ import importlib
 import io
 import os
 import runpy
-import shutil
-import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -1151,7 +1149,7 @@ class CoverageStartupExecutionTestCase(unittest.TestCase):
         ), patch(
             "sys.stdout.isatty",
             return_value=False,
-        ):
+        ), patch.dict(os.environ, {"PORT": "5000"}):
             runpy.run_module("website_app", run_name="__main__")
 
         set_level_mock.assert_called_once_with("INFO")

--- a/test_startup.py
+++ b/test_startup.py
@@ -14,15 +14,25 @@ class StartupPromptTestCase(unittest.TestCase):
         with patch("website_app.sys.stdin.isatty", return_value=False), patch(
             "website_app.sys.stdout.isatty",
             return_value=False,
-        ):
+        ), patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PORT", None)
             options = website_app.run_startup_questions()
 
         self.assertEqual(options["console_level"], "INFO")
         self.assertTrue(options["show_request_logs"])
         self.assertTrue(options["warm_cache"])
         self.assertEqual(options["host"], "0.0.0.0")
-        self.assertEqual(options["port"], 5000)
+        self.assertEqual(options["port"], 443)
         self.assertTrue(options["show_startup_summary"])
+
+    def test_run_startup_questions_reads_port_env(self):
+        with patch("website_app.sys.stdin.isatty", return_value=False), patch(
+            "website_app.sys.stdout.isatty",
+            return_value=False,
+        ), patch.dict(os.environ, {"PORT": "8080"}):
+            options = website_app.run_startup_questions()
+
+        self.assertEqual(options["port"], 8080)
 
     def test_run_startup_questions_reads_interactive_answers(self):
         answers = iter(["debug", "n", "y", "y", "5050", "n"])


### PR DESCRIPTION
## Summary

Daily maintenance: both CI gates on `main` are currently red. This PR brings them back to green without weakening any check.

- **Ruff (lint):** Removed six unused imports — `secrets` in `admin_routes`, `is_logged_in`/`renter_required` in `public_routes`, `g` in `services/security`, and `shutil`/`tempfile` in `test_coverage_full`. None of them had any references in the files.
- **Unit tests:** `test_startup.test_run_startup_questions_uses_defaults_when_non_interactive` and `test_coverage_full.test_main_block_runs_default_startup_path` both still expected port `5000`, but the non-interactive default in `website_app._env_port()` was changed to `443` in commits 0982a23 / df5bfe4 ("Add --no-interactive flag and change default port to 80" / "Change default port from 80 to 443 for SSL"). Updated the non-interactive test to assert `443`, added a small regression test that the `PORT` env var still overrides the default, and made the `runpy`-driven main-block test set `PORT=5000` explicitly so it keeps verifying the same code path it was originally asserting.

No production code paths changed beyond the unused-import deletions.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 677 tests, 1 skipped, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01XH8WQyu9MnKZVKtjUR2pmp)_