### PR TITLE
Fix broken CI: restore default port to 5000, drop unused imports

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 import io
-import secrets
 import uuid as uuid_lib
 
 from flask import Response, abort, current_app, jsonify, redirect, render_template, request, send_file, url_for

--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -5,9 +5,7 @@ from flask import jsonify, render_template, request
 from ..services.auth import (
     get_current_user,
     high_admin_required,
-    is_logged_in,
     login_required,
-    renter_required,
 )
 from ..services.registry import get_services
 from ..services.security import rate_limit

--- a/somewheria_app/services/security.py
+++ b/somewheria_app/services/security.py
@@ -4,7 +4,7 @@ from collections import deque
 from functools import wraps
 from threading import Lock
 
-from flask import abort, current_app, g, jsonify, request, session
+from flask import abort, current_app, jsonify, request, session
 
 
 CSRF_SESSION_KEY = "_csrf_token"

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -3,8 +3,6 @@ import importlib
 import io
 import os
 import runpy
-import shutil
-import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace

--- a/website_app.py
+++ b/website_app.py
@@ -62,7 +62,7 @@ def _env_port() -> int:
         port = int(val)
         if 1 <= port <= 65535:
             return port
-    return 443
+    return 5000
 
 
 def run_startup_questions() -> dict[str, object]:


### PR DESCRIPTION
## Summary

Daily maintenance: `main` was failing both CI jobs (unit tests and ruff).

- **Tests:** Two startup tests (`test_startup.py::test_run_startup_questions_uses_defaults_when_non_interactive`, `test_coverage_full.py::test_main_block_runs_default_startup_path`) expected port `5000`, but recent commits (`0982a23`, `df5bfe4`) drifted the default to `443`. The CLAUDE.md docs also still say `0.0.0.0:5000`, and production overrides via `PORT` env (see `start.sh`, which uses authbind for 80). Restoring `5000` re-aligns code, docs, and tests.
- **Lint:** Removed 6 unused imports flagged by `ruff check .`:
  - `somewheria_app/routes/admin_routes.py`: `secrets`
  - `somewheria_app/routes/public_routes.py`: `is_logged_in`, `renter_required`
  - `somewheria_app/services/security.py`: `flask.g`
  - `test_coverage_full.py`: `shutil`, `tempfile`

Net diff: 5 files, +2/-7 lines.

## Test plan

- [x] `ruff check .` — clean
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 676 passed, 1 skipped
- [ ] CI green on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01TdQFp8dWreqGvwZUJXK2pT)_