### PR TITLE
Restore default port to 5000

### DIFF
--- a/website_app.py
+++ b/website_app.py
@@ -62,7 +62,7 @@ def _env_port() -> int:
         port = int(val)
         if 1 <= port <= 65535:
             return port
-    return 443
+    return 5000
 
 
 def run_startup_questions() -> dict[str, object]:


### PR DESCRIPTION
## Summary

Commit `df5bfe4` ("Change default port from 80 to 443 for SSL") set the non-interactive startup default to **443**. This broke two tests on `main` and contradicted the documented contract.

```
FAIL: test_run_startup_questions_uses_defaults_when_non_interactive (test_startup)
    AssertionError: 443 != 5000
FAIL: test_main_block_runs_default_startup_path (test_coverage_full)
    fake_app.run.assert_called_once_with("0.0.0.0", port=5000, debug=False)
```

`CLAUDE.md` explicitly documents the contract:

> When stdin is not a TTY (CI, supervisord, Docker), it skips prompts and reads `LOG_LEVEL`, `HOST`, `PORT` from env, defaulting to `0.0.0.0:5000`.

The history of this file (`ab12f82` "Fix broken CI: restore default port to 5000", `92cc5ad` "Fix CI: restore documented port-5000 default") shows this default has been re-broken and re-fixed twice before. Port 443 is also a poor default because it requires root privileges and a TLS certificate — operators who really need it can set `PORT=443` explicitly.

This one-line change (`_env_port()` returns `5000` instead of `443`) restores the documented behavior and turns the test suite green.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 676 passed, 1 skipped (was 2 failures, 1 skipped)
- [x] `test_run_startup_questions_uses_defaults_when_non_interactive` now passes
- [x] `test_main_block_runs_default_startup_path` now passes
- [x] No changes to interactive prompt behavior or `PORT` env var handling — only the fallback default changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1U55mNUy17Jk2s1xDh8BE)_