### PR TITLE
Fix approval emails landing in admin inbox; unblock CI

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 import io
-import secrets
 import uuid as uuid_lib
 
 from flask import Response, abort, current_app, jsonify, redirect, render_template, request, send_file, url_for
@@ -495,12 +494,14 @@ def admin_registrations():
             services.notifications.send_email(
                 "Registration Approved",
                 "Your registration for Somewheria has been approved. You can now log in.",
+                to=email,
             )
         elif action == "reject":
             services.storage.remove_pending_registration(email)
             services.notifications.send_email(
                 "Registration Rejected",
                 "Your registration for Somewheria was not approved at this time.",
+                to=email,
             )
         else:
             return render_template(
@@ -535,6 +536,7 @@ def admin_lead_captures():
                 "Thanks for signing up",
                 "Thanks for signing up to be notified when a new property is listed at Somewheria. "
                 "We'll reach out as soon as something becomes available.",
+                to=email,
             )
         elif action == "reject":
             # Silent reject — no email to the requester.

--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -5,9 +5,7 @@ from flask import jsonify, render_template, request
 from ..services.auth import (
     get_current_user,
     high_admin_required,
-    is_logged_in,
     login_required,
-    renter_required,
 )
 from ..services.registry import get_services
 from ..services.security import rate_limit

--- a/somewheria_app/services/security.py
+++ b/somewheria_app/services/security.py
@@ -4,7 +4,7 @@ from collections import deque
 from functools import wraps
 from threading import Lock
 
-from flask import abort, current_app, g, jsonify, request, session
+from flask import abort, current_app, jsonify, request, session
 
 
 CSRF_SESSION_KEY = "_csrf_token"

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -3,8 +3,6 @@ import importlib
 import io
 import os
 import runpy
-import shutil
-import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -391,6 +391,7 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         set_role_mock.assert_called_once_with("pending@example.com", "renter")
         remove_pending_mock.assert_called_once_with("pending@example.com")
         send_email_mock.assert_called_once()
+        self.assertEqual(send_email_mock.call_args.kwargs.get("to"), "pending@example.com")
 
     def test_admin_registrations_reject_calls_storage_and_email(self):
         self.login_as("admin")
@@ -413,6 +414,7 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         remove_pending_mock.assert_called_once_with("pending@example.com")
         send_email_mock.assert_called_once()
+        self.assertEqual(send_email_mock.call_args.kwargs.get("to"), "pending@example.com")
 
     def test_admin_users_page_loads(self):
         self.login_as("admin")
@@ -997,6 +999,7 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         remove_mock.assert_called_once_with("lead@example.com")
         send_email_mock.assert_called_once()
+        self.assertEqual(send_email_mock.call_args.kwargs.get("to"), "lead@example.com")
 
     def test_admin_lead_captures_reject_removes_silently(self):
         self.login_as("admin")

--- a/website_app.py
+++ b/website_app.py
@@ -62,7 +62,7 @@ def _env_port() -> int:
         port = int(val)
         if 1 <= port <= 65535:
             return port
-    return 443
+    return 5000
 
 
 def run_startup_questions() -> dict[str, object]:


### PR DESCRIPTION
## Summary

Three independent issues caught by today's maintenance survey of `main`.

### 1. Bug: approval/rejection emails went to admin, not the user

`admin_routes.admin_registrations` (approve **and** reject) and `admin_routes.admin_lead_captures` (approve) called `NotificationService.send_email(subject, body)` without passing `to=`. `send_email` then fell back to `self.config.email_recipient` — the admin address — so the messages confirming "Your registration has been approved" / "Your registration was not approved" / "Thanks for signing up" all landed in the **admin inbox** instead of going to the renter or lead being notified. The UI redirect told users to expect an email; they never got one.

Fix: pass `to=email` at the three call sites in `somewheria_app/routes/admin_routes.py`.

The bug was invisible to the test suite because the three relevant tests in `test_routes_expanded.py` only asserted `send_email_mock.assert_called_once()`. Tightened them to also assert `send_email_mock.call_args.kwargs["to"]` matches the user's email so this can't regress silently.

Other `send_email` call sites that intentionally omit `to=` (new-registration notice, new-lead notice, viewing-appointment request, report-an-issue, ticket-related errors) were verified — those *should* go to the admin, so they're correct as-is.

### 2. CI red: startup tests asserted port 5000, code defaulted to 443

Commit `df5bfe4` ("Change default port from 80 to 443 for SSL") changed the non-TTY fallback in `_env_port()` to **443**, breaking two tests on every push:

- `test_startup.test_run_startup_questions_uses_defaults_when_non_interactive` — `AssertionError: 443 != 5000`
- `test_coverage_full.test_main_block_runs_default_startup_path` — `Expected: mock('0.0.0.0', port=5000, debug=False)`

`CLAUDE.md` documents the contract:

> When stdin is not a TTY (CI, supervisord, Docker), it skips prompts and reads `LOG_LEVEL`, `HOST`, `PORT` from env, defaulting to `0.0.0.0:5000`.

443 is also a poor dev default — it requires root and a TLS cert. Production deployments set `PORT` explicitly (`start.sh` uses authbind for 80; systemd / Docker set env directly). Restored `_env_port()` to return `5000` so code, docs, and tests all agree.

### 3. CI red: `ruff check .` failed on 6 unused imports (F401)

Removed:
- `somewheria_app/routes/admin_routes.py`: `secrets`
- `somewheria_app/routes/public_routes.py`: `is_logged_in`, `renter_required`
- `somewheria_app/services/security.py`: `flask.g`
- `test_coverage_full.py`: `shutil`, `tempfile`

## Test plan

- [x] `ruff check .` → all checks passed
- [x] `DISABLE_BACKGROUND_THREADS=1 FLASK_ENV=development SECRET_KEY=ci-only-not-for-prod python -m unittest discover` → 676 passed, 1 skipped, 0 failures (was 2 failing before)
- [x] Verified the three buggy call sites; verified the other five `send_email` sites without `to=` are intentionally admin-bound

---
_Generated by [Claude Code](https://claude.ai/code/session_017d6CMfDfV2KvkSEYV9Sg6L)_