### PR TITLE
Fix red CI on main: prune dead imports, refresh stale port assertions

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 import io
-import secrets
 import uuid as uuid_lib
 
 from flask import Response, abort, current_app, jsonify, redirect, render_template, request, send_file, url_for

--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -5,9 +5,7 @@ from flask import jsonify, render_template, request
 from ..services.auth import (
     get_current_user,
     high_admin_required,
-    is_logged_in,
     login_required,
-    renter_required,
 )
 from ..services.registry import get_services
 from ..services.security import rate_limit

--- a/somewheria_app/services/security.py
+++ b/somewheria_app/services/security.py
@@ -4,7 +4,7 @@ from collections import deque
 from functools import wraps
 from threading import Lock
 
-from flask import abort, current_app, g, jsonify, request, session
+from flask import abort, current_app, jsonify, request, session
 
 
 CSRF_SESSION_KEY = "_csrf_token"

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -3,8 +3,6 @@ import importlib
 import io
 import os
 import runpy
-import shutil
-import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -1142,7 +1140,17 @@ class CoverageStartupExecutionTestCase(unittest.TestCase):
         )
         fake_logger = Mock()
 
-        with patch("somewheria_app.create_app", return_value=fake_app), patch(
+        # Strip PORT/HOST/LOG_LEVEL so the non-interactive defaults branch
+        # returns the in-code defaults rather than whatever the surrounding
+        # env happens to set.
+        env_overrides = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in {"PORT", "HOST", "LOG_LEVEL"}
+        }
+        with patch.dict(os.environ, env_overrides, clear=True), patch(
+            "somewheria_app.create_app", return_value=fake_app
+        ), patch(
             "somewheria_app.services.console.get_console_logger",
             return_value=fake_logger,
         ), patch("somewheria_app.services.console.set_console_log_level") as set_level_mock, patch(
@@ -1157,7 +1165,7 @@ class CoverageStartupExecutionTestCase(unittest.TestCase):
         set_level_mock.assert_called_once_with("INFO")
         fake_services.properties.refresh_cache.assert_called_once()
         fake_services.appointments.print_check_file.assert_called_once()
-        fake_app.run.assert_called_once_with("0.0.0.0", port=5000, debug=False)
+        fake_app.run.assert_called_once_with("0.0.0.0", port=443, debug=False)
 
 
 if __name__ == "__main__":

--- a/test_startup.py
+++ b/test_startup.py
@@ -11,7 +11,18 @@ website_app = importlib.import_module("website_app")
 
 class StartupPromptTestCase(unittest.TestCase):
     def test_run_startup_questions_uses_defaults_when_non_interactive(self):
-        with patch("website_app.sys.stdin.isatty", return_value=False), patch(
+        # Clear PORT/HOST/LOG_LEVEL so the non-interactive branch returns the
+        # in-code defaults instead of whatever the surrounding env happens to
+        # set. patch.dict with clear=False merges; we drop the keys we care
+        # about by passing an explicit removal dict via a clean context.
+        env_overrides = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in {"PORT", "HOST", "LOG_LEVEL"}
+        }
+        with patch.dict(os.environ, env_overrides, clear=True), patch(
+            "website_app.sys.stdin.isatty", return_value=False
+        ), patch(
             "website_app.sys.stdout.isatty",
             return_value=False,
         ):
@@ -21,7 +32,7 @@ class StartupPromptTestCase(unittest.TestCase):
         self.assertTrue(options["show_request_logs"])
         self.assertTrue(options["warm_cache"])
         self.assertEqual(options["host"], "0.0.0.0")
-        self.assertEqual(options["port"], 5000)
+        self.assertEqual(options["port"], 443)
         self.assertTrue(options["show_startup_summary"])
 
     def test_run_startup_questions_reads_interactive_answers(self):


### PR DESCRIPTION
## Summary

`main` is currently red on two CI checks ([CI run 25705711779](https://github.com/kltef/Somewheria-LLC-Rental-Property-Website/actions/runs/25705711779) on the merged PR #34). The default startup port was switched 5000 → 80 → 443 across #34 + the follow-up commit, but the tests / lint check that depend on that value were not updated. Today's daily-maintenance survey turned this up as the most substantive backend issue: every push since #34 has been merging through red CI.

### What this PR changes

1. **Ruff fixes (6 unused imports).** All trivially dead — none are re-exported, none are referenced anywhere in the file:
   - `somewheria_app/routes/admin_routes.py` — `secrets`
   - `somewheria_app/routes/public_routes.py` — `is_logged_in`, `renter_required`
   - `somewheria_app/services/security.py` — `flask.g`
   - `test_coverage_full.py` — `shutil`, `tempfile`
2. **Update two stale port assertions** to match the production default of 443:
   - `test_startup.py::test_run_startup_questions_uses_defaults_when_non_interactive` — `options["port"] == 443`
   - `test_coverage_full.py::test_main_block_runs_default_startup_path` — `fake_app.run.assert_called_once_with("0.0.0.0", port=443, debug=False)`
   - While in there, scrub `PORT`/`HOST`/`LOG_LEVEL` from `os.environ` inside the patch context so a runner with `PORT` pre-set can't flake either test. (`_env_port()` reads `$PORT` first, default 443.)

### What this PR does NOT change

No application behaviour. The 443 default lives in `website_app._env_port()` exactly as it does on `main`; this PR only realigns the tests with that intentional code change.

## Test plan

- [x] `ruff check .` — `All checks passed!` (was 6 errors)
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 676 passed, 1 skipped (was 674 + 2 failures)
- [x] Backend-only; templates and HTML untouched per the daily-maintenance scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFdoEis2b7XttzRrmoMani)_