### PR TITLE
Fix red CI on main: align port assertions with code default

### DIFF
--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -1165,7 +1165,7 @@ class CoverageStartupExecutionTestCase(unittest.TestCase):
         set_level_mock.assert_called_once_with("INFO")
         fake_services.properties.refresh_cache.assert_called_once()
         fake_services.appointments.print_check_file.assert_called_once()
-        fake_app.run.assert_called_once_with("0.0.0.0", port=443, debug=False)
+        fake_app.run.assert_called_once_with("0.0.0.0", port=5000, debug=False)
 
 
 if __name__ == "__main__":

--- a/test_startup.py
+++ b/test_startup.py
@@ -33,7 +33,7 @@ class StartupPromptTestCase(unittest.TestCase):
         self.assertTrue(options["show_request_logs"])
         self.assertTrue(options["warm_cache"])
         self.assertEqual(options["host"], "0.0.0.0")
-        self.assertEqual(options["port"], 443)
+        self.assertEqual(options["port"], 5000)
         self.assertTrue(options["show_startup_summary"])
 
     def test_run_startup_questions_reads_port_env(self):


### PR DESCRIPTION
## Summary

`main` is currently red on two startup tests:

- `test_startup.test_run_startup_questions_uses_defaults_when_non_interactive`
- `test_coverage_full.test_main_block_runs_default_startup_path`

Both assert `port == 443`, but `_env_port()` in `website_app.py` returns `5000` when `PORT` is unset. The mismatch comes from PR #41 (commit 9ef672e), which updated the test assertions to 443 on the false premise that the production default was 443. In reality, commit 0e2649a had already restored the default to 5000 — 443 requires root and a TLS cert, so it's a poor unqualified dev default, and `CLAUDE.md` documents the startup default as `0.0.0.0:5000`.

The correct fix is to align the tests with the documented, in-code default of 5000. Production deployments set `PORT` explicitly via env / `start.sh` / authbind; the env-override path is covered by `test_run_startup_questions_reads_port_env` and is unaffected.

## Test plan

- [x] `ruff check .` → all checks passed
- [x] `DISABLE_BACKGROUND_THREADS=1 FLASK_ENV=development SECRET_KEY=ci-only-not-for-prod python -m unittest discover` → 677 passed, 1 skipped, 0 failures
- [ ] CI green on this PR

https://claude.ai/code/session_01MTpquLmH4BNxxTc88YQUuN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTpquLmH4BNxxTc88YQUuN)_