### PR TITLE
Preserve property cache across transient upstream outages

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -40,6 +40,18 @@ class UploadValidationError(ValueError):
     pass
 
 
+class UpstreamUnavailable(RuntimeError):
+    """Raised when the upstream property API cannot be reached.
+
+    Distinguishes a transient network/HTTP failure from a legitimate
+    "upstream has zero properties" response. Callers of
+    :meth:`PropertyService.refresh_cache` rely on this exception to
+    preserve the existing cache during brief outages — without it a 5xx
+    or timeout would silently blank the listing page until the next
+    successful refresh.
+    """
+
+
 def _ensure_safe_image_dimensions(image: Image.Image) -> None:
     width, height = image.size
     if width <= 0 or height <= 0:
@@ -141,6 +153,12 @@ class PropertyService:
             time.sleep(self.config.cache_refresh_interval)
 
     def refresh_cache(self) -> None:
+        # ``fetch_all_properties`` propagates ``UpstreamUnavailable`` from
+        # ``_fetch_property_ids`` on a network / HTTP failure; we let it
+        # bubble up so the caller (route handler, periodic worker) can
+        # decide what to do. The local ``self.cache`` is only reassigned
+        # *after* a successful fetch, so a raise here preserves the
+        # previous cache rather than blanking the listings.
         latest = self.fetch_all_properties()
         with self.cache_lock:
             self.cache = latest
@@ -223,15 +241,24 @@ class PropertyService:
         return [property_info for property_info in results if property_info]
 
     def _fetch_property_ids(self) -> list[str]:
+        # Network / HTTP failure raises ``UpstreamUnavailable`` so callers
+        # (refresh_cache, _refresh_with_change_log) can leave the existing
+        # cache intact instead of overwriting it with the empty list a bare
+        # ``return []`` would produce on a 5xx or timeout.
         try:
             response = requests.get(f"{self.config.api_base_url}/propertiesforrent", timeout=20)
             response.raise_for_status()
             payload = response.json()
-        except Exception:
-            return []
+        except Exception as exc:
+            raise UpstreamUnavailable(
+                f"property id listing unavailable: {exc}"
+            ) from exc
         # A malformed upstream payload (string, list, dict-of-non-list, …) must
         # not silently iterate as characters or unrelated keys downstream — that
-        # would spray the upstream API with junk per-id requests.
+        # would spray the upstream API with junk per-id requests. These shapes
+        # are treated as "upstream returned no properties" rather than a
+        # transient failure, matching the prior behavior for valid-but-empty
+        # responses.
         if not isinstance(payload, dict):
             return []
         ids = payload.get("property_ids", [])

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -188,11 +188,55 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(property_ids, ["prop-1", "prop-2"])
         response.raise_for_status.assert_called_once()
 
-    def test_fetch_property_ids_returns_empty_list_on_failure(self):
-        with patch("somewheria_app.services.properties.requests.get", side_effect=RuntimeError("boom")):
-            property_ids = self.service._fetch_property_ids()
+    def test_fetch_property_ids_raises_upstream_unavailable_on_failure(self):
+        # A network/HTTP failure must surface as ``UpstreamUnavailable`` so
+        # ``refresh_cache`` can leave the existing cache in place. Returning
+        # an empty list here would silently clobber the listings during a
+        # transient upstream outage.
+        from somewheria_app.services.properties import UpstreamUnavailable
 
-        self.assertEqual(property_ids, [])
+        with patch(
+            "somewheria_app.services.properties.requests.get",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertRaises(UpstreamUnavailable):
+                self.service._fetch_property_ids()
+
+    def test_refresh_cache_preserves_existing_cache_on_upstream_failure(self):
+        # The current cache must NOT be blanked when the upstream property
+        # API is temporarily unreachable. ``refresh_cache`` propagates the
+        # ``UpstreamUnavailable`` so the route's try/except can fall back
+        # to serving whatever's already cached.
+        from somewheria_app.services.properties import UpstreamUnavailable
+
+        self.service.cache = [{"id": "prop-1", "name": "Maple"}]
+        with patch.object(
+            self.service,
+            "_fetch_property_ids",
+            side_effect=UpstreamUnavailable("upstream down"),
+        ):
+            with self.assertRaises(UpstreamUnavailable):
+                self.service.refresh_cache()
+
+        self.assertEqual(self.service.cache, [{"id": "prop-1", "name": "Maple"}])
+
+    def test_refresh_with_change_log_preserves_cache_on_upstream_failure(self):
+        # ``_refresh_with_change_log`` is invoked from a daemon thread for
+        # admin-triggered refreshes; an upstream blip there must also leave
+        # the cache (and the change log) untouched rather than recording a
+        # spurious "everything was deleted" delta.
+        from somewheria_app.services.properties import UpstreamUnavailable
+
+        self.service.cache = [{"id": "prop-1", "name": "Maple"}]
+        with patch.object(
+            self.service,
+            "fetch_all_properties",
+            side_effect=UpstreamUnavailable("upstream down"),
+        ):
+            self.service._refresh_with_change_log("admin@example.com")
+
+        self.assertEqual(self.service.cache, [{"id": "prop-1", "name": "Maple"}])
+        self.notifications.log_site_change.assert_not_called()
 
     def test_fetch_property_ids_rejects_non_dict_payload(self):
         # A misbehaving upstream that returns a top-level list/string must not

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -145,6 +145,42 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(payload[0]["name"], "Maple House")
         self.assertCountEqual(payload[0]["included_amenities"], ["Parking", "Laundry"])
 
+    def test_for_rent_serves_cached_properties_when_upstream_is_down(self):
+        # Regression: a transient upstream outage used to blank the
+        # listing page because ``_fetch_property_ids`` swallowed the
+        # exception and ``refresh_cache`` then overwrote the cache with
+        # an empty list. Now the upstream failure propagates as
+        # ``UpstreamUnavailable``, the route's try/except catches it,
+        # and the previously-cached properties remain visible.
+        from somewheria_app.services.properties import UpstreamUnavailable
+
+        self.seed_property()
+        with patch.object(
+            self.services.properties,
+            "refresh_cache",
+            side_effect=UpstreamUnavailable("upstream down"),
+        ):
+            response = self.client.get("/for-rent")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Maple House", response.data)
+
+    def test_for_rent_json_serves_cached_properties_when_upstream_is_down(self):
+        from somewheria_app.services.properties import UpstreamUnavailable
+
+        self.seed_property()
+        with patch.object(
+            self.services.properties,
+            "refresh_cache",
+            side_effect=UpstreamUnavailable("upstream down"),
+        ):
+            response = self.client.get("/for-rent.json")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["name"], "Maple House")
+
     def test_for_rent_refresh_uses_anonymous_actor_when_logged_out(self):
         with patch.object(self.services.properties, "trigger_background_refresh") as trigger_mock:
             response = self.client.get("/for-rent-refresh.json")


### PR DESCRIPTION
## Summary

Fixes a real, user-visible bug where a transient outage of the upstream property API (timeout, 5xx) would blank `/for-rent` and `/for-rent.json` until the next successful refresh.

### Root cause

`_fetch_property_ids` caught every exception and returned `[]`. `refresh_cache` then took that empty list and overwrote `self.cache`, deleting all cached properties. The `/for-rent` route already wrapped `refresh_cache` in `try/except` expecting an exception path on upstream failure — but that branch was dead code, since the exception had been silently swallowed two layers down.

### Fix

- Introduce `UpstreamUnavailable` exception so network/HTTP errors propagate distinctly from "upstream returned no properties."
- `_fetch_property_ids` now raises `UpstreamUnavailable` on network/HTTP errors. Malformed-but-valid payloads (wrong shape, non-list IDs, non-string entries) still return `[]` — unchanged behavior.
- `fetch_all_properties` propagates naturally.
- `refresh_cache` only reassigns `self.cache` after a successful fetch, so a raise preserves the previous cache.
- `_refresh_with_change_log`'s existing outer `try/except` catches the exception and avoids logging a phantom "everything deleted" delta.
- Route-level `try/except` in `/for-rent` and `/for-rent.json` (already present) now actually does what its comment said: falls back to whatever's in cache when upstream is down.

### Tests

- Updated `test_fetch_property_ids_returns_empty_list_on_failure` → `test_fetch_property_ids_raises_upstream_unavailable_on_failure` to assert the new contract.
- Added `test_refresh_cache_preserves_existing_cache_on_upstream_failure` — the central regression guard.
- Added `test_refresh_with_change_log_preserves_cache_on_upstream_failure` — admin-triggered path doesn't blank the cache or log a spurious change.
- Added `test_for_rent_serves_cached_properties_when_upstream_is_down` and `_json` variant — end-to-end route-level guard.

## Test plan

- [x] `python -m unittest discover` — 681 tests, all green
- [x] `ruff check .` — clean
- [x] Manual smoke: simulated timeout via mock, confirmed `UpstreamUnavailable` raised and cache preserved

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wvat868UkyMwya4QJyA7yK)_