### PR TITLE
Block path traversal in contract PDF deletion

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -642,6 +642,26 @@ def _validate_contract_pdf(uploaded_file) -> bytes | None:
     return raw
 
 
+def _safe_contract_pdf_path(services, pdf_filename: str):
+    """Resolve a stored contract PDF filename to an absolute path inside the
+    upload directory, or return None if the name is missing or escapes the
+    upload root. Filenames are generated server-side as ``<uuid>.pdf`` and
+    should never contain separators, but ``renter_contracts.json`` can be
+    hand-edited, so this re-validates before any filesystem op (download or
+    delete) to prevent path traversal."""
+    if not pdf_filename:
+        return None
+    if "/" in pdf_filename or "\\" in pdf_filename or ".." in pdf_filename:
+        return None
+    upload_root = services.config.contract_upload_dir.resolve()
+    pdf_path = (services.config.contract_upload_dir / pdf_filename).resolve()
+    try:
+        pdf_path.relative_to(upload_root)
+    except ValueError:
+        return None
+    return pdf_path
+
+
 @admin_required
 def admin_contracts():
     services = get_services()
@@ -699,13 +719,15 @@ def admin_contracts():
                     contract_idx = int(contract_index)
                     if renter_email in contracts_data and 0 <= contract_idx < len(contracts_data[renter_email]):
                         removed = contracts_data[renter_email][contract_idx]
-                        # Best-effort delete of the on-disk PDF.
+                        # Best-effort delete of the on-disk PDF. Validate the
+                        # filename the same way the download path does so a
+                        # tampered ``pdf_filename`` can't unlink an arbitrary
+                        # file outside the upload directory.
                         pdf_filename = removed.get("pdf_filename") or ""
-                        if pdf_filename:
+                        safe_pdf_path = _safe_contract_pdf_path(services, pdf_filename)
+                        if safe_pdf_path is not None:
                             try:
-                                services.storage.delete_file(
-                                    services.config.contract_upload_dir / pdf_filename
-                                )
+                                services.storage.delete_file(safe_pdf_path)
                             except Exception:
                                 pass
                         del contracts_data[renter_email][contract_idx]
@@ -795,20 +817,11 @@ def contract_download(contract_id: str):
     if not contract:
         abort(404)
     pdf_filename = contract.get("pdf_filename") or ""
-    if not pdf_filename:
-        abort(404)
-    # Defense-in-depth: only the bare filename component is honoured. The
-    # filename was generated server-side as ``<uuid>.pdf`` so it should never
-    # contain separators, but be paranoid in case of hand-edited storage.
-    if "/" in pdf_filename or "\\" in pdf_filename or ".." in pdf_filename:
-        abort(404)
-    pdf_path = (services.config.contract_upload_dir / pdf_filename).resolve()
-    upload_root = services.config.contract_upload_dir.resolve()
-    try:
-        pdf_path.relative_to(upload_root)
-    except ValueError:
-        abort(404)
-    if not pdf_path.exists():
+    # Defense-in-depth: re-validate the stored filename against path traversal
+    # before touching the filesystem (filenames are server-generated UUIDs but
+    # storage can be hand-edited).
+    pdf_path = _safe_contract_pdf_path(services, pdf_filename)
+    if pdf_path is None or not pdf_path.exists():
         abort(404)
     try:
         return send_file(

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -678,6 +678,27 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"Contract removed for renter@example.com.", response.data)
         save_contracts_mock.assert_called_once_with({})
 
+    def test_admin_contracts_delete_rejects_traversal_pdf_filename(self):
+        self.login_as("admin")
+        contracts = {
+            "renter@example.com": [
+                {"property_name": "Maple House", "pdf_filename": "../../../etc/passwd"}
+            ]
+        }
+        with patch.object(self.services.storage, "get_renter_contracts", return_value=contracts), patch.object(
+            self.services.storage,
+            "save_renter_contracts",
+        ), patch.object(self.services.storage, "delete_file") as delete_file_mock:
+            response = self.client.post(
+                "/admin/contracts",
+                data={"action": "delete", "renter_email": "renter@example.com", "contract_index": "0"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Contract removed for renter@example.com.", response.data)
+        # The traversal filename must never reach the filesystem layer.
+        delete_file_mock.assert_not_called()
+
     def test_analytics_dashboard_forbids_standard_admin(self):
         self.login_as("admin")
 


### PR DESCRIPTION
## Summary

The contract **download** path (`admin_routes.py`) already re-validates the stored `pdf_filename` against path traversal (rejects `/`, `\`, `..`, and confirms the resolved path stays inside the upload root) before touching the filesystem. The contract **delete** path did not — it passed `removed["pdf_filename"]` straight into `contract_upload_dir / pdf_filename` and `delete_file`.

Filenames are generated server-side as `<uuid>.pdf`, but `renter_contracts.json` is hand-editable JSON storage. A tampered value like `../../../etc/passwd` would let the delete action unlink an arbitrary file on disk.

This PR closes that asymmetry:

- Extracts the download-side guard into a shared `_safe_contract_pdf_path(services, pdf_filename)` helper that returns a validated absolute path inside the upload dir, or `None`.
- Uses it in both the download and delete paths.
- Adds a regression test (`test_admin_contracts_delete_rejects_traversal_pdf_filename`) asserting a traversal filename never reaches the storage layer while the contract record is still removed.

## Test plan

- [x] `python -m unittest discover` — 682 tests pass (added 1)
- [x] `ruff check .` — clean

https://claude.ai/code/session_01GJjLK3UxiNgS4cqgkpFWiS

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJjLK3UxiNgS4cqgkpFWiS)_