### PR TITLE
Fix crash-email storm on dynamic routes

### DIFF
--- a/somewheria_app/__init__.py
+++ b/somewheria_app/__init__.py
@@ -2,7 +2,7 @@ import os
 import threading
 import time
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import Flask, render_template, request
 from werkzeug.exceptions import HTTPException
@@ -178,16 +178,22 @@ def create_app() -> Flask:
         try:
             path = request.path
             method = request.method
+            endpoint = request.endpoint or ""
             ua = request.headers.get("User-Agent", "")
             remote = request.headers.get("X-Forwarded-For", request.remote_addr or "")
         except Exception:
-            path, method, ua, remote = "(unknown)", "(unknown)", "(unknown)", "(unknown)"
+            path, method, endpoint = "(unknown)", "(unknown)", ""
+            ua, remote = "(unknown)", "(unknown)"
 
-        fingerprint = f"{type(exc).__name__}:{path}"[:200]
+        # Fingerprint by Flask endpoint when available so /property/<uuid> et al.
+        # collapse to a single suppression key instead of one per parameter
+        # value — without this, a sustained crash on a dynamic route would
+        # send one email per unique URL and defeat the 10-min cooldown.
+        fingerprint = f"{type(exc).__name__}:{endpoint or path}"[:200]
 
         body = (
             "The website hit an unhandled error and served the bare fallback response.\n\n"
-            f"Time:    {datetime.utcnow().isoformat()}Z\n"
+            f"Time:    {datetime.now(timezone.utc).replace(tzinfo=None).isoformat()}Z\n"
             f"Request: {method} {path}\n"
             f"Client:  {remote}\n"
             f"Agent:   {ua}\n"

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -857,6 +857,45 @@ class CoverageAnalyticsAndFactoryTestCase(unittest.TestCase):
         self.assertEqual(client.get("/force-503").status_code, 503)
         self.assertEqual(client.get("/force-504").status_code, 504)
 
+    def test_crash_handler_dedupes_dynamic_route_crashes_by_endpoint(self):
+        # Regression: previously fingerprinted by raw URL path, so every
+        # /thing/<param> value crashed to a distinct fingerprint and the
+        # 10-min cooldown never fired — risking an email storm. Fingerprint
+        # is now keyed on the Flask endpoint, which is stable across
+        # parameter values.
+        import threading
+        import time as time_module
+
+        with patch.dict(os.environ, {"DISABLE_BACKGROUND_THREADS": "1"}, clear=False):
+            app = create_app()
+        app.config.update(TESTING=False, PROPAGATE_EXCEPTIONS=False)
+
+        @app.route("/thing/<param>")
+        def thing_view(param):
+            raise RuntimeError(f"boom-{param}")
+
+        services = app.extensions["somewheria_services"]
+        send_calls: list[tuple[str, str]] = []
+        send_event = threading.Event()
+
+        def fake_send(subject, body, **kwargs):
+            send_calls.append((subject, body))
+            send_event.set()
+            return True
+
+        services.notifications.send_email = fake_send
+
+        client = app.test_client()
+        for value in ("aaa", "bbb", "ccc"):
+            self.assertEqual(client.get(f"/thing/{value}").status_code, 503)
+
+        # The worker that calls send_email is spawned on a daemon thread.
+        # Wait briefly for at least one to fire; the assertion below verifies
+        # that exactly one fired (the others were suppressed by fingerprint).
+        send_event.wait(timeout=2.0)
+        time_module.sleep(0.1)  # give any racing extra threads a chance to land
+        self.assertEqual(len(send_calls), 1)
+
     def test_before_request_skips_static_endpoint(self):
         with self.app.test_client() as client:
             client.get("/static/missing.css")


### PR DESCRIPTION
## Summary

- The crash handler in `somewheria_app/__init__.py` fingerprinted by raw URL path, so a sustained outage on a parametrized route like `/property/<uuid>` or `/edit-listing/<id>` produced a distinct fingerprint per parameter value. The 10-minute cooldown was therefore keyed per-URL rather than per-route, so admins could receive hundreds of crash emails for what is structurally one failure.
- Fix: fingerprint by `request.endpoint` (the Flask route name, stable across parameter values), with fallback to `path` when no endpoint matched (404s).
- Also dropped the deprecated `datetime.utcnow()` in the same handler for the timezone-aware equivalent (no observable format change).
- Added a regression test that hits a dynamic crashing route three times with different parameters and asserts `notifications.send_email` fires once.

## Test plan

- [x] `python -m unittest discover` — 682 tests pass (was 681 before this change).
- [x] `ruff check .` — clean.
- [x] New test `CoverageAnalyticsAndFactoryTestCase.test_crash_handler_dedupes_dynamic_route_crashes_by_endpoint` exercises the fingerprint dedup.

https://claude.ai/code/session_011R9TAs7gGV4DRn4c5wyGkf

---
_Generated by [Claude Code](https://claude.ai/code/session_011R9TAs7gGV4DRn4c5wyGkf)_