### PR TITLE
Bound appointment dates and modernize ticket timestamps

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -16,6 +16,11 @@ MAX_CONTACT_LEN = 200
 MAX_DESCRIPTION_LEN = 4000
 MAX_DATE_LEN = 10
 
+# Cap appointment requests at a year out. Legitimate viewings happen within a
+# few weeks; nothing realistic needs more lead time, and an unbounded date
+# field invites year-9999 junk that wastes admin attention.
+MAX_APPOINTMENT_DAYS_AHEAD = 365
+
 ALLOWED_CONTACT_METHODS = {"email", "phone", "text", "sms", "call"}
 
 
@@ -116,6 +121,11 @@ def schedule_appointment(uuid):
         return jsonify(success=False, error="Invalid date."), 400
     if requested_date < datetime.date.today():
         return jsonify(success=False, error="Date cannot be in the past."), 400
+    if requested_date > datetime.date.today() + datetime.timedelta(days=MAX_APPOINTMENT_DAYS_AHEAD):
+        return jsonify(
+            success=False,
+            error=f"Date must be within {MAX_APPOINTMENT_DAYS_AHEAD} days.",
+        ), 400
 
     property_name = services.properties.fetch_live_property_name(uuid)
     if not property_name:

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -64,7 +64,15 @@ MAX_NAME_LEN = 120
 
 
 def _now_iso() -> str:
-    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    # ``datetime.utcnow()`` is deprecated in Python 3.12+; use an aware UTC
+    # now and strip the tzinfo so the wire format stays a bare
+    # ``YYYY-MM-DDTHH:MM:SSZ`` string identical to what older tickets carry.
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0, tzinfo=None)
+        .isoformat()
+        + "Z"
+    )
 
 
 class TicketService:

--- a/test_jira_integration.py
+++ b/test_jira_integration.py
@@ -1,5 +1,6 @@
 """Tests for Phase 3 §6 — JIRA scaffold + webhook + CSRF exemption."""
 
+import datetime
 import json
 import os
 import tempfile
@@ -14,7 +15,7 @@ os.environ["DISABLE_BACKGROUND_THREADS"] = "1"
 
 from somewheria_app import create_app  # noqa: E402
 from somewheria_app.services.jira import JiraClient  # noqa: E402
-from somewheria_app.services.tickets import TicketService  # noqa: E402
+from somewheria_app.services.tickets import TicketService, _now_iso  # noqa: E402
 
 
 class JiraClientTestCase(unittest.TestCase):
@@ -64,6 +65,28 @@ class JiraClientTestCase(unittest.TestCase):
                 "title": "t", "description": "d", "priority": prio,
                 "category": "other",
             }), "STUB-1")
+
+
+class NowIsoFormatTestCase(unittest.TestCase):
+    """Lock the on-disk timestamp shape so the move off the deprecated
+    ``datetime.utcnow()`` cannot silently drift the format. Existing ticket
+    JSON files are parsed as ``YYYY-MM-DDTHH:MM:SSZ`` strings; any change
+    would break the admin dashboard's sort and the JIRA mirror payload."""
+
+    def test_now_iso_matches_expected_shape(self):
+        value = _now_iso()
+        self.assertRegex(value, r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+    def test_now_iso_returns_utc(self):
+        before = datetime.datetime.now(datetime.timezone.utc)
+        value = _now_iso()
+        after = datetime.datetime.now(datetime.timezone.utc)
+        # Parse the stamp back as UTC and assert it falls within the window.
+        parsed = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=datetime.timezone.utc
+        )
+        self.assertLessEqual(before.replace(microsecond=0), parsed)
+        self.assertLessEqual(parsed, after)
 
 
 class TicketServiceJiraWiringTestCase(unittest.TestCase):

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -242,6 +242,22 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json()["error"], "Date cannot be in the past.")
 
+    def test_schedule_appointment_rejects_far_future_date(self):
+        too_far = (datetime.date.today() + datetime.timedelta(days=400)).isoformat()
+
+        response = self.client.post(
+            "/property/prop-1/schedule",
+            json={
+                "name": "Alex",
+                "date": too_far,
+                "contact_method": "email",
+                "contact_info": "alex@example.com",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("within", response.get_json()["error"])
+
     def test_schedule_appointment_returns_404_when_property_is_missing(self):
         future_date = (datetime.date.today() + datetime.timedelta(days=5)).isoformat()
         with patch.object(self.services.properties, "fetch_live_property_name", return_value=None):


### PR DESCRIPTION
## Summary

Two backend improvements found during daily maintenance:

1. **Cap future appointment dates.** `/property/<uuid>/schedule` accepted any future date, including year-9999 junk that would waste admin attention. Bound at 365 days ahead — longer than any realistic property viewing lead time and still permissive for relocators planning months out. Returns a 400 with a friendly error message.

2. **Modernize ticket timestamps.** `tickets._now_iso()` called `datetime.datetime.utcnow()`, which is deprecated in Python 3.12+ and slated for removal. Switched to a UTC-aware `datetime.now(timezone.utc)` and strip the `tzinfo` so the on-disk format stays bit-for-bit identical (`YYYY-MM-DDTHH:MM:SSZ`) — existing `tickets.json` keeps parsing without migration.

Both ship with new tests:
- `test_schedule_appointment_rejects_far_future_date` — verifies the 365-day cap.
- `NowIsoFormatTestCase` — locks the on-disk timestamp shape and asserts UTC, so a future format drift can't slip through.

Full suite (688 tests) passes locally.

## Test plan

- [x] `python -m unittest discover` — all green
- [x] Targeted new tests pass
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01HhVYad32xjRASxwivHAsR7)_