### PR TITLE
Delete orphaned ticket photo when JSON save fails

### DIFF
--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -500,6 +500,16 @@ class TicketService:
         try:
             self._save(tickets)
         except Exception as exc:
+            # The photo is on disk but the ticket record never picked it up.
+            # Leaving it would orphan the file under static/uploads/tickets/
+            # forever — best-effort delete so the upload dir doesn't grow
+            # unboundedly on repeated save failures.
+            try:
+                self.storage.delete_file(save_path)
+            except Exception:
+                self.logger.warning(
+                    "Failed to clean up orphaned ticket photo %s", save_path
+                )
             self.logger.error("Failed to persist ticket photos: %s", exc)
             raise UploadValidationError("Failed to record photo on ticket.") from exc
 

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -1474,6 +1474,67 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
                 except OSError:
                     pass
 
+    def test_ticket_service_add_photo_cleans_orphan_on_save_failure(self):
+        """If persisting the ticket JSON fails after the photo is on disk,
+        the orphaned image file must be removed so static/uploads/tickets/
+        doesn't accumulate dead bytes on every save error."""
+        from somewheria_app.services.properties import UploadValidationError
+
+        services = self.services
+        with patch.object(services.notifications, "send_email", return_value=True):
+            ticket = services.tickets.create_ticket(
+                {
+                    "title": "Outlet",
+                    "description": "Sparks",
+                    "category": "electrical",
+                    "priority": "urgent",
+                },
+                "renter@example.com",
+            )
+        ticket_dir = self.services.config.ticket_upload_dir / ticket["id"]
+        try:
+
+            class _Upload:
+                def __init__(self, name, blob):
+                    self.filename = name
+                    self.stream = BytesIO(blob)
+
+            with patch.object(
+                services.tickets, "_save", side_effect=OSError("disk full")
+            ):
+                with self.assertRaises(UploadValidationError):
+                    services.tickets.add_photo(
+                        ticket["id"],
+                        _Upload("orphan.png", self._png_bytes()),
+                        "renter@example.com",
+                    )
+
+            # The photo must NOT remain on disk after a failed save.
+            if ticket_dir.exists():
+                remaining = list(ticket_dir.iterdir())
+                self.assertEqual(
+                    remaining,
+                    [],
+                    f"expected ticket upload dir to be empty, found {remaining}",
+                )
+        finally:
+            if ticket_dir.exists():
+                for child in ticket_dir.iterdir():
+                    try:
+                        child.unlink()
+                    except OSError:
+                        pass
+                try:
+                    ticket_dir.rmdir()
+                except OSError:
+                    pass
+            tickets_file = self.services.config.tickets_file
+            if tickets_file.exists():
+                try:
+                    tickets_file.unlink()
+                except OSError:
+                    pass
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`TicketService.add_photo` (in `somewheria_app/services/tickets.py`) writes the uploaded image to disk via `storage.save_binary_file(...)` and then calls `_save(tickets)` to record the new photo URL onto the ticket. If the JSON save raised (disk full, permission flip, transient FS error, etc.), the photo file was already on disk under `static/uploads/tickets/<ticket_id>/<random>.<ext>` with no reference from any ticket — an orphan that nothing ever cleans up. Repeated failures accumulate dead bytes forever.

This change best-effort `delete_file`s the just-written photo when `_save` raises, before re-raising the user-facing `UploadValidationError`.

## Test plan

- [x] New unit test (`test_ticket_service_add_photo_cleans_orphan_on_save_failure`) patches `_save` to raise `OSError` and asserts the ticket upload directory is empty after the call raises.
- [x] Existing photo upload tests still pass.
- [x] Full suite: `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 686 tests pass.

https://claude.ai/code/session_01FbxSTet1oCmadMfiDFdXKN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbxSTet1oCmadMfiDFdXKN)_