### PR TITLE
Tighten email validation across registration, lead capture, and SMTP send

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -16,6 +16,7 @@ from ..services.auth import (
 from ..services.properties import BLANK_PROPERTY, UploadValidationError
 from ..services.registry import get_services
 from ..services.security import rate_limit
+from ..services.validation import is_valid_email
 
 
 ALLOWED_ROLES = ("renter", "admin", "high_admin")
@@ -459,7 +460,7 @@ def register():
         name = request.form.get("name", "").strip()[:120]
         email = request.form.get("email", "").strip().lower()[:254]
         reason = request.form.get("reason", "").strip()[:2000]
-        if not name or not email or "@" not in email:
+        if not name or not is_valid_email(email):
             return render_template("register.html", error="Name and a valid email are required.")
         existing = services.storage.get_pending_registrations()
         if any(item.get("email", "").lower() == email for item in existing):

--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -9,6 +9,7 @@ from ..services.auth import (
 )
 from ..services.registry import get_services
 from ..services.security import rate_limit
+from ..services.validation import is_valid_email
 
 
 MAX_NAME_LEN = 120
@@ -176,7 +177,7 @@ def report_issue():
 def submit_lead_capture():
     services = get_services()
     email = (request.form.get("email") or "").strip().lower()[:254]
-    if not email or "@" not in email:
+    if not is_valid_email(email):
         return jsonify(success=False, error="A valid email is required."), 400
     services.storage.add_pending_lead_capture(
         {

--- a/somewheria_app/services/notifications.py
+++ b/somewheria_app/services/notifications.py
@@ -7,6 +7,7 @@ import smtplib
 from email.message import EmailMessage
 
 from .console import get_console_logger
+from .validation import is_valid_email
 
 
 class NotificationService:
@@ -22,7 +23,7 @@ class NotificationService:
             return False
 
         recipient = (to or self.config.email_recipient or "").strip()
-        if not recipient or "@" not in recipient:
+        if not is_valid_email(recipient):
             self.console.warning("No valid recipient for email '%s' (to=%r); skipping.", subject, to)
             return False
 

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -27,6 +27,7 @@ from .properties import (
     UploadValidationError,
     _ensure_safe_image_dimensions,
 )
+from .validation import is_valid_email
 
 
 MAX_TICKET_PHOTOS = 5
@@ -343,7 +344,7 @@ class TicketService:
         if not ticket.get("email_updates"):
             return
         recipient = (ticket.get("submitted_by") or "").strip()
-        if not recipient or "@" not in recipient:
+        if not is_valid_email(recipient):
             return
         try:
             self.notifications.send_email(subject, body, to=recipient)

--- a/somewheria_app/services/validation.py
+++ b/somewheria_app/services/validation.py
@@ -1,0 +1,42 @@
+"""Lightweight input validators shared across services and routes.
+
+Kept deliberately small: just the rules we want to enforce at the
+public boundary (registration form, lead capture, ticket email
+recipients). Anything more involved should live with the service it
+belongs to.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# Practical email regex. Not the full RFC 5321 grammar — that's both
+# too permissive (allows quoted-strings and IP literals nobody actually
+# uses) and surprisingly hard to express — but covers the everyday
+# "local@domain.tld" shape we want to accept and rejects the obvious
+# junk the previous "@ in value" check let through ("@", "a@", "@b",
+# "a@b", "a b@c.com"). RFC 5321 caps the total length at 254 bytes.
+_EMAIL_REGEX = re.compile(
+    r"^[A-Za-z0-9._%+\-!#$&'*/=?^`{|}~]+"
+    r"@"
+    r"[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?)+$"
+)
+
+
+def is_valid_email(value) -> bool:
+    """Return True when ``value`` is a plausible deliverable email address.
+
+    Rejects non-strings, anything outside the RFC 5321 length bounds,
+    values containing whitespace, and values that don't fit the
+    standard ``local@domain.tld`` shape. The previous check (just
+    ``"@" in value``) accepted ``"@"`` and ``"a@b"`` — exactly the
+    sort of junk that pollutes the lead-capture and pending-registration
+    JSON files and triggers wasted SMTP attempts.
+    """
+    if not isinstance(value, str):
+        return False
+    if len(value) < 3 or len(value) > 254:
+        return False
+    return _EMAIL_REGEX.match(value) is not None

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -342,6 +342,20 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Name and a valid email are required.", response.data)
 
+    def test_register_rejects_malformed_email(self):
+        for garbage in ("@", "a@", "@b.com", "a@b"):
+            with patch.object(self.services.storage, "add_pending_registration") as add_mock, patch.object(
+                self.services.notifications, "send_email"
+            ) as send_email_mock:
+                response = self.client.post(
+                    "/register",
+                    data={"name": "Jamie", "email": garbage, "reason": "Need access"},
+                )
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b"Name and a valid email are required.", response.data)
+            add_mock.assert_not_called()
+            send_email_mock.assert_not_called()
+
     def test_register_saves_pending_registration_and_sends_email(self):
         with patch.object(self.services.storage, "get_pending_registrations", return_value=[]), patch.object(
             self.services.storage,
@@ -1069,6 +1083,17 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         response = self.client.post("/lead-captures", data={"email": "not-an-email"})
         self.assertEqual(response.status_code, 400)
         self.assertIn(b"valid email", response.data)
+
+    def test_submit_lead_capture_rejects_malformed_emails(self):
+        # Catches the cases the previous "@ in value" check let through.
+        for garbage in ("@", "a@", "@b.com", "a@b", "user @example.com"):
+            with patch.object(self.services.storage, "add_pending_lead_capture") as add_mock, patch.object(
+                self.services.notifications, "send_email"
+            ) as send_email_mock:
+                response = self.client.post("/lead-captures", data={"email": garbage})
+            self.assertEqual(response.status_code, 400, garbage)
+            add_mock.assert_not_called()
+            send_email_mock.assert_not_called()
 
     def test_submit_lead_capture_saves_and_emails(self):
         with patch.object(self.services.storage, "add_pending_lead_capture") as add_mock, patch.object(

--- a/test_services.py
+++ b/test_services.py
@@ -11,6 +11,7 @@ from somewheria_app.services.auth import AuthService
 from somewheria_app.services.notifications import NotificationService
 from somewheria_app.services.properties import PropertyService
 from somewheria_app.services.storage import FileStorageService
+from somewheria_app.services.validation import is_valid_email
 
 
 class DummyForm:
@@ -1127,6 +1128,49 @@ class ZillowPublisherTestCase(unittest.TestCase):
         self.assertIn("success_count", snapshot)
         self.assertIn("failure_count", snapshot)
         self.assertIn("recent_errors", snapshot)
+
+
+class EmailValidationTestCase(unittest.TestCase):
+    def test_accepts_typical_addresses(self):
+        for value in (
+            "user@example.com",
+            "first.last@example.co.uk",
+            "user+tag@sub.example.com",
+            "a@b.co",
+            "USER@EXAMPLE.COM",
+            "hyphen-name@domain-with-hyphen.io",
+            "name_1@example.museum",
+        ):
+            self.assertTrue(is_valid_email(value), value)
+
+    def test_rejects_obvious_junk(self):
+        for value in (
+            "",
+            "@",
+            "a@",
+            "@b.com",
+            "a@b",                # no TLD
+            "a@b.",               # trailing dot
+            "a@.b",               # leading dot in domain
+            "a@b..c",             # consecutive dots
+            "user @example.com",  # space in local
+            "user@exa mple.com",  # space in domain
+            "user@@example.com",  # multiple @
+            "not-an-email",
+            "user@-example.com",  # label starts with hyphen
+            "user@example-.com",  # label ends with hyphen
+        ):
+            self.assertFalse(is_valid_email(value), value)
+
+    def test_rejects_non_strings(self):
+        self.assertFalse(is_valid_email(None))
+        self.assertFalse(is_valid_email(12345))
+        self.assertFalse(is_valid_email(["a@b.com"]))
+        self.assertFalse(is_valid_email({"email": "a@b.com"}))
+
+    def test_rejects_oversized_strings(self):
+        long_local = "a" * 255
+        self.assertFalse(is_valid_email(f"{long_local}@example.com"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The previous email check (`"@" in value`) accepted obvious junk like `"@"`, `"a@"`, `"@b.com"`, and `"a@b"` (no TLD). That polluted `pending_registrations.json` / `pending_lead_captures.json` and triggered wasted SMTP attempts to undeliverable addresses.

This change adds a small shared `is_valid_email()` helper (`somewheria_app/services/validation.py`) and routes the four call sites through it:

- `POST /lead-captures` — public lead capture form
- `POST /register` — public registration form
- `NotificationService.send_email` — recipient guard before SMTP
- `TicketService._maybe_email_submitter` — guard on the submitter address before sending ticket updates

The validator is a practical regex (not full RFC 5321) that requires the standard `local@domain.tld` shape, RFC 5321 length bounds, and no whitespace.

## Test plan

- [x] `python -m unittest discover` — 691 tests pass, 0 failures (6 new)
- [x] `ruff check .` — clean
- [x] New `EmailValidationTestCase` covers accepts/rejects/non-strings/oversized
- [x] New route-level tests assert the four worst false-positives (`"@"`, `"a@"`, `"@b.com"`, `"a@b"`) are now rejected by `/lead-captures` and `/register` without touching storage or SMTP
- [x] Existing tests using `lead@example.com`, `jamie@example.com`, `recipient@example.com` still pass unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01BraHZ2GFwkDYxwwRegKsgg)_