### PR TITLE
Set timeout on SMTP connection to bound thread stalls on Gmail outage

### DIFF
--- a/somewheria_app/services/notifications.py
+++ b/somewheria_app/services/notifications.py
@@ -9,6 +9,15 @@ from email.message import EmailMessage
 from .console import get_console_logger
 
 
+# Hard cap on the SMTP socket so a slow / unreachable Gmail relay can't hang
+# the calling thread indefinitely. Crash-handler emails run in daemon
+# threads — without a timeout, an outage upstream would silently accumulate
+# stuck threads (one per unique crash fingerprint per 10 minutes) holding
+# sockets and file descriptors. 30s is generous for a real TLS+login+send
+# round trip while still bounding worst-case stalls.
+SMTP_TIMEOUT_SECONDS = 30
+
+
 class NotificationService:
     def __init__(self, config, analytics) -> None:
         self.config = config
@@ -34,7 +43,7 @@ class NotificationService:
         message.add_alternative(self._html_email_body(subject, body), subtype="html")
 
         try:
-            with smtplib.SMTP("smtp.gmail.com", 587) as server:
+            with smtplib.SMTP("smtp.gmail.com", 587, timeout=SMTP_TIMEOUT_SECONDS) as server:
                 server.starttls()
                 server.login(self.config.email_sender, app_password)
                 server.send_message(message)

--- a/test_services.py
+++ b/test_services.py
@@ -526,10 +526,19 @@ class NotificationServiceTestCase(unittest.TestCase):
 
         with patch.object(self.service, "_email_password", return_value="app-pass"), patch(
             "somewheria_app.services.notifications.smtplib.SMTP", return_value=smtp_context
-        ):
+        ) as smtp_ctor:
             result = self.service.send_email("Test Subject", "Hello world")
 
         self.assertTrue(result)
+        # The SMTP constructor MUST be called with a timeout so a slow / hung
+        # Gmail relay cannot block the calling thread forever — crash-handler
+        # emails run in daemon threads and would otherwise pile up.
+        ctor_kwargs = smtp_ctor.call_args.kwargs
+        ctor_args = smtp_ctor.call_args.args
+        self.assertEqual(ctor_args[0], "smtp.gmail.com")
+        self.assertEqual(ctor_args[1], 587)
+        self.assertIn("timeout", ctor_kwargs)
+        self.assertGreater(ctor_kwargs["timeout"], 0)
         smtp_instance.starttls.assert_called_once()
         smtp_instance.login.assert_called_once_with("sender@example.com", "app-pass")
         smtp_instance.send_message.assert_called_once()


### PR DESCRIPTION
## Summary

Every `requests.*` call in the codebase already passes a timeout, but `smtplib.SMTP("smtp.gmail.com", 587)` in `NotificationService.send_email` was constructed without one — so a slow or unreachable Gmail SMTP relay would block the calling thread on the underlying socket connect indefinitely (Python's default socket timeout is `None`).

The crash-handler email path is the worst case: it fires from a daemon thread per unique `(ExceptionType, endpoint)` every 10 minutes. With no SMTP timeout, a sustained Gmail outage would silently pile up stuck threads holding sockets and file descriptors.

This change:
- Adds a 30s timeout to the SMTP constructor — generous for a real STARTTLS + login + send round trip while bounding worst-case stalls.
- Extends the existing `test_send_email_returns_true_on_success` test to assert the constructor receives a positive `timeout` kwarg so future regressions get caught at CI.

## Test plan

- [x] `python -m unittest discover` — all 685 tests pass locally
- [x] `ruff check .` — clean
- [ ] CI green on this branch

https://claude.ai/code/session_01X7GuDdawqzvTLznAgp9bRc

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7GuDdawqzvTLznAgp9bRc)_