### PR TITLE
Coerce null upstream description so properties don't drop from the listing

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -332,8 +332,16 @@ class PropertyService:
         normalized.setdefault("sqft", "N/A")
         normalized.setdefault("deposit", "N/A")
         normalized.setdefault("address", "N/A")
-        normalized["description"] = normalized.get("description", "")
-        normalized.setdefault("blurb", normalized["description"])
+        # Coerce a null / non-string description to "". Upstream occasionally
+        # returns ``"description": null`` for partially-filled listings; without
+        # this the ``.lower()`` call below raises AttributeError, fetch_property_record
+        # swallows it as a generic "failed to fetch", and the property drops out
+        # of the listing entirely.
+        description = normalized.get("description")
+        if not isinstance(description, str):
+            description = ""
+        normalized["description"] = description
+        normalized.setdefault("blurb", description)
         normalized.setdefault("lease_length", "12 months")
         normalized.setdefault("name", "Property")
         normalized.setdefault("photos", [])

--- a/test_services.py
+++ b/test_services.py
@@ -333,6 +333,27 @@ class PropertyServiceTestCase(unittest.TestCase):
 
         self.assertEqual(normalized["thumbnail"], "photo-1.jpg")
 
+    def test_normalize_property_coerces_null_description_to_empty_string(self):
+        # Upstream sometimes returns ``"description": null`` for partially
+        # filled listings. Previously this crashed in the pets-inference branch
+        # (``description.lower()`` on None) — fetch_property_record swallowed the
+        # exception and the property silently dropped out of the listing.
+        normalized = self.service.normalize_property(
+            {"name": "Maple", "description": None}, "prop-1"
+        )
+
+        self.assertEqual(normalized["description"], "")
+        self.assertEqual(normalized["blurb"], "")
+        self.assertEqual(normalized["pets_allowed"], "Unknown")
+
+    def test_normalize_property_coerces_non_string_description_to_empty_string(self):
+        normalized = self.service.normalize_property(
+            {"name": "Maple", "description": 42}, "prop-1"
+        )
+
+        self.assertEqual(normalized["description"], "")
+        self.assertEqual(normalized["blurb"], "")
+
     def test_property_payload_from_form_merges_custom_amenities(self):
         form = DummyForm(
             values={


### PR DESCRIPTION
## Summary

`PropertyService.normalize_property` called `normalized["description"].lower()` inside the pets-allowed inference fallback. When the upstream property API returned `"description": null` for a partially-filled listing, that raised `AttributeError`. `fetch_property_record`'s broad `try/except` swallowed the exception and returned `None`, so the property silently disappeared from `/for-rent` and `/for-rent.json` — a data-loss bug that admins wouldn't notice unless they were counting listings.

Reproduced locally:

```
>>> svc.normalize_property({'name': 'X', 'description': None}, 'p1')
AttributeError: 'NoneType' object has no attribute 'lower'
```

## Changes

- `somewheria_app/services/properties.py` — coerce a non-string `description` to `""` before the inference branch. The coerced string also seeds `blurb`'s `setdefault` so the derived field can't inherit `None` either.
- `test_services.py` — two regression tests covering the `None` case and the non-string case.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 687 tests pass (685 prior + 2 new), 1 skipped
- [x] `ruff check .` — clean
- [x] Manual repro confirms `normalize_property({'description': None}, ...)` now returns `description=""`, `blurb=""`, `pets_allowed="Unknown"` instead of raising
- [ ] CI green on this branch

https://claude.ai/code/session_01HfVADHRRkULDL5yAWi9gpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfVADHRRkULDL5yAWi9gpY)_