### PR TITLE
Coerce null included_amenities so properties don't drop from the listing

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -326,6 +326,14 @@ class PropertyService:
         if property_id:
             normalized["id"] = property_id
         normalized.setdefault("included_amenities", normalized.get("included_utilities", []))
+        # Mirror the description/photos coercion: upstream occasionally returns
+        # ``"included_amenities": null`` (or a misshaped non-list) for partially
+        # filled listings. Without this guard the ``any()`` iteration in the
+        # pets-inference branch below raises TypeError, fetch_property_record
+        # swallows it as a generic "failed to fetch", and the property drops
+        # out of the listing entirely.
+        if not isinstance(normalized["included_amenities"], list):
+            normalized["included_amenities"] = []
         normalized.setdefault("bedrooms", "N/A")
         normalized.setdefault("bathrooms", "N/A")
         normalized.setdefault("rent", "N/A")

--- a/test_services.py
+++ b/test_services.py
@@ -354,6 +354,44 @@ class PropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(normalized["description"], "")
         self.assertEqual(normalized["blurb"], "")
 
+    def test_normalize_property_coerces_null_included_amenities_to_empty_list(self):
+        # Same upstream-shape bug as the description coercion above: a
+        # ``"included_amenities": null`` payload made the pets-inference branch
+        # iterate over None and raise TypeError, which fetch_property_record
+        # swallowed as a generic failure so the property dropped silently from
+        # the listing.
+        normalized = self.service.normalize_property(
+            {"name": "Maple", "included_amenities": None}, "prop-1"
+        )
+
+        self.assertEqual(normalized["included_amenities"], [])
+        self.assertEqual(normalized["pets_allowed"], "Unknown")
+
+    def test_normalize_property_infers_pets_from_description_when_amenities_null(self):
+        # The null-amenities guard must not block the description fallback
+        # for pet inference.
+        normalized = self.service.normalize_property(
+            {
+                "name": "Maple",
+                "included_amenities": None,
+                "description": "Dog-friendly home; pet deposit required.",
+            },
+            "prop-1",
+        )
+
+        self.assertEqual(normalized["included_amenities"], [])
+        self.assertEqual(normalized["pets_allowed"], "Yes")
+
+    def test_normalize_property_coerces_non_list_included_amenities_to_empty_list(self):
+        # A malformed upstream payload that returns a string (or any other
+        # non-list) for included_amenities must not crash; the string would
+        # iterate per-character and silently misclassify the pets flag.
+        normalized = self.service.normalize_property(
+            {"name": "Maple", "included_amenities": "Parking, Laundry"}, "prop-1"
+        )
+
+        self.assertEqual(normalized["included_amenities"], [])
+
     def test_property_payload_from_form_merges_custom_amenities(self):
         form = DummyForm(
             values={


### PR DESCRIPTION
## Summary

Same upstream-shape bug class as #61 (null description). When the properties API returns `"included_amenities": null` for a partially filled listing, `normalize_property` iterated over `None` in the pets-inference branch and raised `TypeError`. `fetch_property_record` swallowed that as a generic failure and the property silently dropped out of `/for-rent`.

Mirrors the existing description/photos coercion pattern: validate the type after `setdefault` and replace anything that isn't a `list` with `[]`. Adds three regression tests covering `null`, `null` with a description fallback for pet inference, and a misshaped non-list value.

## Test plan

- [x] `python -m unittest discover` — 690 passing
- [x] `ruff check .` — clean
- [x] Manual repro: `normalize_property({"included_amenities": None})` no longer raises

https://claude.ai/code/session_01NoFfb5oK4QpTkz5JEiM1cR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoFfb5oK4QpTkz5JEiM1cR)_