### PR TITLE
Validate property id before outbound DELETE to block path traversal

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -845,6 +845,8 @@ def delete_listing(id):
         except Exception:
             pass
         return redirect(url_for("manage_listings"))
+    except KeyError:
+        return "Property not found", 404
     except Exception as exc:
         services.notifications.log_and_notify_error(
             "Property Delete Error",

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -540,6 +540,14 @@ class PropertyService:
         self._safe_zillow_publish("publish_update", {**update_payload, "id": property_id})
 
     def delete_property(self, property_id: str, actor_email: str) -> None:
+        # Validate the id at the boundary so a malformed value (e.g. "../foo"
+        # routed through Flask's default <string> converter) can't smuggle
+        # path segments into the outbound DELETE URL. ``update_property`` and
+        # ``toggle_sale`` are implicitly protected because they look the id
+        # up in the cache first; ``delete_property`` skips that lookup so the
+        # check has to live here.
+        if not PROPERTY_ID_PATTERN.match(property_id or ""):
+            raise KeyError("Invalid property id.")
         response = requests.delete(f"{self.config.api_base_url}/properties/{property_id}", timeout=20)
         if response.status_code not in (200, 204):
             raise RuntimeError(f"Remote API responded {response.status_code}: {response.text}")

--- a/test_services.py
+++ b/test_services.py
@@ -390,6 +390,21 @@ class PropertyServiceTestCase(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 self.service.delete_property("prop-1", "admin@example.com")
 
+    def test_delete_property_rejects_invalid_id_before_outbound_call(self):
+        # A traversal-style id must be rejected at the boundary so a
+        # malformed value can't be smuggled into the outbound DELETE URL.
+        # KeyError matches the "not found" semantics the route handler maps
+        # to a 404 response.
+        self.service.cache = [{"id": "prop-1"}]
+        with patch("somewheria_app.services.properties.requests.delete") as delete_mock:
+            with self.assertRaises(KeyError):
+                self.service.delete_property("../../etc/passwd", "admin@example.com")
+
+        delete_mock.assert_not_called()
+        # Cache must be untouched when validation fails.
+        self.assertEqual(self.service.cache, [{"id": "prop-1"}])
+        self.notifications.log_site_change.assert_not_called()
+
     def test_toggle_sale_updates_cache_and_status(self):
         self.service.cache = [{"id": "prop-1", "for_sale": False, "status": "Active"}]
         with patch("somewheria_app.services.properties.requests.put") as put_mock:


### PR DESCRIPTION
## Summary

- `PropertyService.delete_property` was forwarding the route-supplied id straight into `requests.delete(...)` without validating it. Every other boundary that takes a property id (`fetch_property_record`, `fetch_live_property_name`, `upload_image`) already enforces `PROPERTY_ID_PATTERN` so a malformed value can't smuggle path segments into the outbound URL. `update_property` and `toggle_sale` are implicitly protected because they look the id up in the cache first, but `delete_property` skipped that lookup.
- Apply the same `PROPERTY_ID_PATTERN` check at the boundary, surfaced as `KeyError` to match the "property not found" semantics the rest of the service raises.
- Map that `KeyError` to a 404 in the `delete_listing` route handler (instead of the catch-all 500), matching the pattern already used by `save_edit` and `toggle_sale`.
- Add a regression test in `test_services.py` asserting that a traversal-style id (`../../etc/passwd`) is rejected before any outbound HTTP call and leaves the cache untouched.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` (688 tests pass, +1 new)
- [x] `python -m unittest test_services` (focused service-layer run)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C3vjj2Js1a9kSbFQ6XRU9b)_