### PR TITLE
Suppress duplicate "New Lead Capture" admin emails

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -178,16 +178,21 @@ def submit_lead_capture():
     email = (request.form.get("email") or "").strip().lower()[:254]
     if not email or "@" not in email:
         return jsonify(success=False, error="A valid email is required."), 400
-    services.storage.add_pending_lead_capture(
+    added = services.storage.add_pending_lead_capture(
         {
             "email": email,
             "submitted_at": datetime.datetime.now().isoformat(),
         }
     )
-    services.notifications.send_email(
-        "New Lead Capture",
-        f"New 'notify me' lead from {email}. Approve at /admin/lead-captures",
-    )
+    # Only notify admins on a genuinely new lead. Repeated submissions of an
+    # already-pending address are accepted silently so a hostile client can't
+    # spam the admin inbox by replaying the same email — mirrors the dedup
+    # guard /register has had since the registration flow was introduced.
+    if added:
+        services.notifications.send_email(
+            "New Lead Capture",
+            f"New 'notify me' lead from {email}. Approve at /admin/lead-captures",
+        )
     return jsonify(success=True)
 
 

--- a/somewheria_app/services/sql_storage.py
+++ b/somewheria_app/services/sql_storage.py
@@ -236,22 +236,26 @@ class SqlStorageService:
             ).fetchall()
         return [loads(row["payload"]) for row in rows]
 
-    def add_pending_lead_capture(self, lead: dict) -> None:
+    def add_pending_lead_capture(self, lead: dict) -> bool:
         # Mirror FileStorageService: de-duplicate by email so a repeated
-        # submission doesn't bloat the table or flood the admin UI.
+        # submission doesn't bloat the table or flood the admin UI. Returns
+        # True when newly inserted, False on duplicate or missing email — the
+        # caller relies on the bool to skip the "new lead" admin email when
+        # the address is already pending.
         target_email = (lead.get("email") or "").strip().lower()
         if not target_email:
-            return
+            return False
         with self.db.transaction() as conn:
             existing = conn.execute(
                 "SELECT 1 FROM lead_captures WHERE email = ?", (target_email,)
             ).fetchone()
             if existing is not None:
-                return
+                return False
             conn.execute(
                 "INSERT INTO lead_captures(email, payload) VALUES (?, ?)",
                 (target_email, dumps(lead)),
             )
+        return True
 
     def remove_pending_lead_capture(self, email: str) -> None:
         email_lc = (email or "").strip().lower()

--- a/somewheria_app/services/storage.py
+++ b/somewheria_app/services/storage.py
@@ -99,15 +99,20 @@ class FileStorageService:
     def get_pending_lead_captures(self) -> list[dict]:
         return self.load_json_file(self.config.lead_capture_file, [], expected_type=list)
 
-    def add_pending_lead_capture(self, lead: dict) -> None:
+    def add_pending_lead_capture(self, lead: dict) -> bool:
+        # Returns True when the lead was newly persisted, False when it was
+        # rejected as a duplicate. The caller uses the return value to decide
+        # whether to fire the "new lead" admin email — without that gate a
+        # repeated submission of an already-pending address spams the inbox.
         leads = self.get_pending_lead_captures()
         # De-duplicate by email so a repeated submission doesn't bloat the file
         # or give the requester a way to flood the admin UI.
         target_email = (lead.get("email") or "").lower()
         if target_email and any(item.get("email", "").lower() == target_email for item in leads):
-            return
+            return False
         leads.append(lead)
         self.save_json_file(self.config.lead_capture_file, leads)
+        return True
 
     def remove_pending_lead_capture(self, email: str) -> None:
         leads = [

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -1071,7 +1071,9 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"valid email", response.data)
 
     def test_submit_lead_capture_saves_and_emails(self):
-        with patch.object(self.services.storage, "add_pending_lead_capture") as add_mock, patch.object(
+        with patch.object(
+            self.services.storage, "add_pending_lead_capture", return_value=True
+        ) as add_mock, patch.object(
             self.services.notifications, "send_email"
         ) as send_email_mock:
             response = self.client.post(
@@ -1085,6 +1087,25 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(called_with["email"], "lead@example.com")
         self.assertIn("submitted_at", called_with)
         send_email_mock.assert_called_once()
+
+    def test_submit_lead_capture_duplicate_does_not_reemail_admins(self):
+        # A repeat POST for an already-pending email must not send a second
+        # "New Lead Capture" notification — otherwise an attacker can spam the
+        # admin inbox at the rate-limit ceiling just by replaying the form.
+        # The user-facing response is still success=True so the dedup state
+        # isn't leaked to unauthenticated callers.
+        with patch.object(
+            self.services.storage, "add_pending_lead_capture", return_value=False
+        ) as add_mock, patch.object(
+            self.services.notifications, "send_email"
+        ) as send_email_mock:
+            response = self.client.post(
+                "/lead-captures", data={"email": "dup@example.com"}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json().get("success"))
+        add_mock.assert_called_once()
+        send_email_mock.assert_not_called()
 
     def test_admin_lead_captures_page_loads_for_admin(self):
         self.login_as("admin")

--- a/test_services.py
+++ b/test_services.py
@@ -157,9 +157,10 @@ class FileStorageServiceTestCase(unittest.TestCase):
         with patch.object(
             self.service, "get_pending_lead_captures", return_value=[{"email": "keep@example.com"}]
         ), patch.object(self.service, "save_json_file") as save_json_mock:
-            self.service.add_pending_lead_capture(
+            result = self.service.add_pending_lead_capture(
                 {"email": "new@example.com", "submitted_at": "2026-01-01"}
             )
+        self.assertTrue(result)
         save_json_mock.assert_called_once_with(
             self.config.lead_capture_file,
             [
@@ -169,11 +170,14 @@ class FileStorageServiceTestCase(unittest.TestCase):
         )
 
     def test_add_pending_lead_capture_dedupes_existing_email(self):
-        # Repeated submissions with the same email should not bloat the file.
+        # Repeated submissions with the same email should not bloat the file,
+        # and must report False so the route layer can skip the admin email
+        # instead of replaying it on every duplicate POST.
         with patch.object(
             self.service, "get_pending_lead_captures", return_value=[{"email": "dup@example.com"}]
         ), patch.object(self.service, "save_json_file") as save_json_mock:
-            self.service.add_pending_lead_capture({"email": "dup@example.com"})
+            result = self.service.add_pending_lead_capture({"email": "dup@example.com"})
+        self.assertFalse(result)
         save_json_mock.assert_not_called()
 
     def test_remove_pending_lead_capture_filters_matching_email(self):

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -120,22 +120,27 @@ class LeadCapturesTestCase(SqlStorageBaseTestCase):
     """Regression coverage for the lead-capture flow under SQLite."""
 
     def test_add_pending_lead_capture(self):
-        self.storage.add_pending_lead_capture(
+        added = self.storage.add_pending_lead_capture(
             {"email": "lead@example.com", "submitted_at": "2026-01-01"}
         )
+        self.assertTrue(added)
         leads = self.storage.get_pending_lead_captures()
         self.assertEqual(len(leads), 1)
         self.assertEqual(leads[0]["email"], "lead@example.com")
         self.assertEqual(leads[0]["submitted_at"], "2026-01-01")
 
     def test_add_pending_lead_capture_dedupes_existing_email(self):
-        # Mirror FileStorageService: repeated submissions don't bloat storage.
-        self.storage.add_pending_lead_capture(
+        # Mirror FileStorageService: repeated submissions don't bloat storage,
+        # and the second insert must report False so the public route can
+        # suppress the admin notification email on duplicates.
+        first = self.storage.add_pending_lead_capture(
             {"email": "dup@example.com", "submitted_at": "2026-01-01"}
         )
-        self.storage.add_pending_lead_capture(
+        second = self.storage.add_pending_lead_capture(
             {"email": "dup@example.com", "submitted_at": "2026-02-02"}
         )
+        self.assertTrue(first)
+        self.assertFalse(second)
         leads = self.storage.get_pending_lead_captures()
         self.assertEqual(len(leads), 1)
         self.assertEqual(leads[0]["submitted_at"], "2026-01-01")


### PR DESCRIPTION
## Summary

`/lead-captures` fired a "New Lead Capture" admin email on every POST, even when the submitted address was already pending. The storage layer already de-duplicated by email so the dashboard wasn't bloated, but the route never saw that — it just called `add_pending_lead_capture` and then unconditionally sent the notification. A hostile or careless client could replay the same form at the rate-limit ceiling (3 per 10 min per IP, times any number of IPs) and flood the admin inbox while the lead list stayed clean.

The `/register` route has had the same dedup-before-notify guard since the registration flow was introduced — this brings `/lead-captures` to the same baseline.

## Changes

- `FileStorageService.add_pending_lead_capture` and `SqlStorageService.add_pending_lead_capture` now return `bool`: `True` on a genuine insert, `False` on a duplicate or empty email.
- `submit_lead_capture` (route) only fires the admin notification when storage reports a real insert, but still returns `success=True` to the client either way so the dedup state can't be probed by an unauthenticated POST.
- Regression coverage at both layers: storage helpers return the expected bool, and the route does not call `send_email` when storage reports a duplicate.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 688 tests pass (was 687, +1 new route-level regression).
- [x] `ruff check .` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XWimh4LaVh6CVFgZkjJThd)_