### PR TITLE
Respect explicit upstream pets_allowed instead of substring-inferring

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -347,15 +347,30 @@ class PropertyService:
         normalized.setdefault("photos", [])
         if not isinstance(normalized["photos"], list):
             normalized["photos"] = []
-        pets_allowed = normalized.get("pets_allowed", "Unknown")
-        if isinstance(pets_allowed, bool):
-            pets_allowed = "Yes" if pets_allowed else "No"
-        elif "included_amenities" in normalized and any(
-            "pet" in str(item).lower() for item in normalized["included_amenities"]
-        ):
-            pets_allowed = "Yes"
-        elif "description" in normalized and "pet" in normalized["description"].lower():
-            pets_allowed = "Yes"
+        pets_allowed_raw = normalized.get("pets_allowed", "Unknown")
+        if isinstance(pets_allowed_raw, bool):
+            pets_allowed = "Yes" if pets_allowed_raw else "No"
+        elif isinstance(pets_allowed_raw, str):
+            lowered = pets_allowed_raw.strip().lower()
+            if lowered in {"yes", "true", "1"}:
+                pets_allowed = "Yes"
+            elif lowered in {"no", "false", "0"}:
+                pets_allowed = "No"
+            else:
+                # Only infer from amenities / description when the upstream
+                # value is missing or unrecognized — otherwise a property
+                # whose description reads "No pets allowed" would have its
+                # explicit "No" flipped to "Yes" by the substring match.
+                pets_allowed = "Unknown"
+                if any(
+                    "pet" in str(item).lower()
+                    for item in normalized.get("included_amenities", [])
+                ):
+                    pets_allowed = "Yes"
+                elif "pet" in normalized["description"].lower():
+                    pets_allowed = "Yes"
+        else:
+            pets_allowed = "Unknown"
         normalized["pets_allowed"] = pets_allowed
         ada_accessible = None
         for key in (

--- a/test_generated_matrices.py
+++ b/test_generated_matrices.py
@@ -299,6 +299,20 @@ PETS_CASES = [
     ({"pets_allowed": False, "included_amenities": ["Pet Friendly"]}, "No"),
     ({"pets_allowed": "Unknown", "included_amenities": ["Pet Friendly"]}, "Yes"),
     ({"pets_allowed": "Unknown", "description": "pets ok"}, "Yes"),
+    # An explicit "No" from upstream must win over a substring like "no pets"
+    # in the description or amenities — otherwise a property whose own listing
+    # says "No pets allowed" would render as pets-allowed=Yes.
+    ({"pets_allowed": "No", "description": "No pets allowed"}, "No"),
+    ({"pets_allowed": "No", "included_amenities": ["No pets"]}, "No"),
+    # Explicit "Yes"/"No" (case-insensitive, including true/false/1/0 forms)
+    # should be respected without falling through to the substring inference.
+    ({"pets_allowed": "Yes"}, "Yes"),
+    ({"pets_allowed": "yes"}, "Yes"),
+    ({"pets_allowed": "no"}, "No"),
+    ({"pets_allowed": "true"}, "Yes"),
+    ({"pets_allowed": "false"}, "No"),
+    ({"pets_allowed": "1"}, "Yes"),
+    ({"pets_allowed": "0"}, "No"),
     ({}, "Unknown"),
 ]
 


### PR DESCRIPTION
## Summary

`PropertyService.normalize_property` was flipping `pets_allowed` to `"Yes"` whenever the word `pet` appeared in the description or any amenity — even when the upstream record had already supplied an explicit `"No"`. A property whose listing said *"No pets allowed"* would surface as pets-allowed=Yes.

Root cause: only the `bool` branch was treated as authoritative. A string from upstream fell straight through to the substring-inference `elif`s.

## Fix

Match the existing `ada_accessible` normalization in the same function: bool inputs convert to `Yes`/`No`, recognized string values (`yes`/`no`/`true`/`false`/`1`/`0`, case-insensitive) are honored as-is, and the substring inference applies only when the upstream value is missing or unrecognized.

## Test plan

- [x] `python -m unittest discover` — 697 tests pass (up from 688; 9 new cases for the bug fix in `test_generated_matrices.py`)
- [x] `ruff check .` — clean
- [x] Existing `PETS_CASES` matrix still passes (bool wins, "Unknown" + amenity infers "Yes", etc.)
- [x] New cases codify the fix: `{"pets_allowed": "No", "description": "No pets allowed"}` → `"No"`, and explicit string values like `"yes"`/`"no"`/`"true"`/`"false"`/`"1"`/`"0"` are honored without falling through to inference.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1NnSuVAgQ1dKaSsF1PgMS)_