### PR TITLE
Preserve property cache when every per-property fetch fails

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -238,7 +238,19 @@ class PropertyService:
         property_ids = self._fetch_property_ids()
         with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
             results = list(executor.map(self.fetch_property_record, property_ids))
-        return [property_info for property_info in results if property_info]
+        successful = [property_info for property_info in results if property_info]
+        # If the ID listing came back with properties but EVERY per-property
+        # fetch returned None, that is a systemic outage of the details / photos
+        # endpoint (5xx, timeout, DNS), not "every property was deleted." Raise
+        # so refresh_cache leaves the existing cache in place — mirroring the
+        # behavior already in place for _fetch_property_ids network failures.
+        # Without this guard a brief details-endpoint outage blanks /for-rent
+        # until the next successful refresh.
+        if property_ids and not successful:
+            raise UpstreamUnavailable(
+                f"all {len(property_ids)} per-property fetches failed"
+            )
+        return successful
 
     def _fetch_property_ids(self) -> list[str]:
         # Network / HTTP failure raises ``UpstreamUnavailable`` so callers

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -238,6 +238,56 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(self.service.cache, [{"id": "prop-1", "name": "Maple"}])
         self.notifications.log_site_change.assert_not_called()
 
+    def test_fetch_all_properties_preserves_cache_when_every_record_fetch_fails(self):
+        # IDs listing succeeds, but every per-property details fetch fails
+        # (transient 5xx on the details endpoint). Without the guard,
+        # fetch_all_properties would return [] and refresh_cache would blank
+        # the listings; with the guard it raises UpstreamUnavailable so the
+        # existing cache survives the outage.
+        from somewheria_app.services.properties import UpstreamUnavailable
+
+        self.service.cache = [{"id": "prop-1", "name": "Maple"}]
+        with patch.object(
+            self.service,
+            "_fetch_property_ids",
+            return_value=["prop-1", "prop-2", "prop-3"],
+        ), patch.object(
+            self.service,
+            "fetch_property_record",
+            return_value=None,
+        ):
+            with self.assertRaises(UpstreamUnavailable):
+                self.service.fetch_all_properties()
+            with self.assertRaises(UpstreamUnavailable):
+                self.service.refresh_cache()
+
+        # Cache untouched -- /for-rent's try/except falls back to it.
+        self.assertEqual(self.service.cache, [{"id": "prop-1", "name": "Maple"}])
+
+    def test_fetch_all_properties_returns_partial_results_when_some_records_fetch(self):
+        # Mixed success/failure should NOT raise — return the successful
+        # records (matching pre-existing partial-failure behavior) and let
+        # refresh_cache overwrite. This keeps the new guard narrow: it only
+        # fires when *every* per-property fetch failed.
+        good = {"id": "prop-1", "name": "Maple"}
+        with patch.object(
+            self.service,
+            "_fetch_property_ids",
+            return_value=["prop-1", "prop-2"],
+        ), patch.object(
+            self.service,
+            "fetch_property_record",
+            side_effect=[good, None],
+        ):
+            self.assertEqual(self.service.fetch_all_properties(), [good])
+
+    def test_fetch_all_properties_empty_id_listing_does_not_raise(self):
+        # Upstream legitimately reporting zero properties is not an outage.
+        # An empty ID list must propagate as an empty result so refresh_cache
+        # can clear the cache when properties are actually all removed.
+        with patch.object(self.service, "_fetch_property_ids", return_value=[]):
+            self.assertEqual(self.service.fetch_all_properties(), [])
+
     def test_fetch_property_ids_rejects_non_dict_payload(self):
         # A misbehaving upstream that returns a top-level list/string must not
         # silently iterate as characters or unrelated keys downstream.


### PR DESCRIPTION
## Summary

`_fetch_property_ids` already raises `UpstreamUnavailable` so a network/HTTP failure on the IDs listing leaves the existing cache in place (PR #43 / 4ab3f2f). The companion failure mode — IDs come back fine but every per-property `details` / `photos` fetch fails (transient 5xx on that endpoint, timeout, DNS blip) — was still slipping through:

- `fetch_all_properties` filtered the Nones out and returned `[]`
- `refresh_cache` then overwrote `self.cache = []`
- `/for-rent` and `/for-rent.json` rendered an empty listing until the next successful refresh

Treat the all-fail case symmetrically: when `_fetch_property_ids` returns at least one id and every record fetch came back `None`, raise `UpstreamUnavailable` so the existing route- and worker-level `try/except` blocks fall back to the cached listings.

## Scope

Narrow guard on purpose:

- **Empty id listing** (genuine "upstream has zero properties") still returns `[]` — needed so an actual property purge can clear the cache.
- **Partial failures** (some records fetch, some don't) still return the successful records — same behavior as before. Those records keep getting served; the failing ones reappear on the next successful refresh. The guard only fires when *every* per-property fetch failed.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 700 tests pass (697 baseline + 3 new), 1 skipped
- [x] `ruff check .` — clean
- [x] New tests:
  - `test_fetch_all_properties_preserves_cache_when_every_record_fetch_fails` — asserts `UpstreamUnavailable` raised and cache untouched
  - `test_fetch_all_properties_returns_partial_results_when_some_records_fetch` — locks in the existing partial-success behavior so the new guard can't widen accidentally
  - `test_fetch_all_properties_empty_id_listing_does_not_raise` — locks in the legitimate "zero properties" path

https://claude.ai/code/session_01VAHV7Hf4He1CdjRzDbHqiR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAHV7Hf4He1CdjRzDbHqiR)_