### PR TITLE
Coalesce concurrent /for-rent cache refreshes

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -114,6 +114,16 @@ def sanitize_tour_url(raw: str) -> str:
 
 
 class PropertyService:
+    # Concurrent /for-rent and /for-rent.json hits each used to fire their
+    # own upstream fanout (one ID listing + per-property detail/photos), so
+    # a small burst multiplied AWS API Gateway / Lambda cost N-fold. The
+    # synchronous refresh now serializes on a single lock, and any caller
+    # arriving within REFRESH_COALESCE_SECONDS of the previous attempt
+    # piggybacks on the already-fresh cache without making upstream calls.
+    # The window is small enough that the cache stays effectively
+    # request-fresh and large enough to absorb a realistic burst.
+    REFRESH_COALESCE_SECONDS = 2.0
+
     def __init__(self, config, notifications, zillow=None) -> None:
         self.config = config
         self.notifications = notifications
@@ -125,6 +135,8 @@ class PropertyService:
         self.logger = get_console_logger("properties")
         self.cache = []
         self.cache_lock = threading.Lock()
+        self._refresh_lock = threading.Lock()
+        self._last_refresh_monotonic = 0.0
         self.refresh_thread = None
 
     def _safe_zillow_publish(self, method_name: str, *args, **kwargs) -> None:
@@ -153,16 +165,34 @@ class PropertyService:
             time.sleep(self.config.cache_refresh_interval)
 
     def refresh_cache(self) -> None:
-        # ``fetch_all_properties`` propagates ``UpstreamUnavailable`` from
-        # ``_fetch_property_ids`` on a network / HTTP failure; we let it
-        # bubble up so the caller (route handler, periodic worker) can
+        # Serialize concurrent refreshes so at most one upstream fanout is
+        # in flight per process. Followers that arrive while the leader is
+        # still fetching queue on the lock; once the leader returns, each
+        # follower sees the just-updated timestamp and skips its own
+        # fanout. ``fetch_all_properties`` propagates ``UpstreamUnavailable``
+        # from ``_fetch_property_ids`` on a network / HTTP failure; we let
+        # it bubble up so the caller (route handler, periodic worker) can
         # decide what to do. The local ``self.cache`` is only reassigned
         # *after* a successful fetch, so a raise here preserves the
         # previous cache rather than blanking the listings.
-        latest = self.fetch_all_properties()
-        with self.cache_lock:
-            self.cache = latest
-        self.logger.info("Cache refreshed with %s properties", len(self.cache))
+        with self._refresh_lock:
+            if (
+                time.monotonic() - self._last_refresh_monotonic
+                < self.REFRESH_COALESCE_SECONDS
+            ):
+                return
+            try:
+                latest = self.fetch_all_properties()
+                with self.cache_lock:
+                    self.cache = latest
+                self.logger.info("Cache refreshed with %s properties", len(self.cache))
+            finally:
+                # Record the attempt time on both success AND failure: an
+                # upstream outage means queued followers should serve the
+                # existing cache via the route's UpstreamUnavailable
+                # fallback rather than each retry the dead endpoint in
+                # series.
+                self._last_refresh_monotonic = time.monotonic()
 
     def get_cached_properties(self) -> list[dict]:
         with self.cache_lock:

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -97,6 +97,57 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(self.service.cache, latest)
         info_mock.assert_called_once()
 
+    def test_refresh_cache_coalesces_within_window(self):
+        # Two refreshes back-to-back should only fan out once. The second
+        # caller sees the recent timestamp and skips its own fanout — that's
+        # the cost reduction /for-rent and /for-rent.json depend on when a
+        # burst of visitors land on the same page in parallel.
+        latest = [{"id": "prop-1"}]
+        with patch.object(
+            self.service, "fetch_all_properties", return_value=latest
+        ) as fetch_mock:
+            self.service.refresh_cache()
+            self.service.refresh_cache()
+
+        self.assertEqual(fetch_mock.call_count, 1)
+        self.assertEqual(self.service.cache, latest)
+
+    def test_refresh_cache_refetches_after_window(self):
+        latest = [{"id": "prop-1"}]
+        with patch.object(
+            self.service, "fetch_all_properties", return_value=latest
+        ) as fetch_mock:
+            self.service.refresh_cache()
+            # Force the coalesce window to lapse without sleeping.
+            self.service._last_refresh_monotonic -= (
+                self.service.REFRESH_COALESCE_SECONDS + 1.0
+            )
+            self.service.refresh_cache()
+
+        self.assertEqual(fetch_mock.call_count, 2)
+
+    def test_refresh_cache_failure_still_coalesces_followers(self):
+        # An upstream outage records the attempt time too, so a queued
+        # follower doesn't immediately re-hit a dead endpoint. The route
+        # handler's existing UpstreamUnavailable fallback serves the cache
+        # for both leader and follower.
+        from somewheria_app.services.properties import UpstreamUnavailable
+
+        self.service.cache = [{"id": "prop-1", "name": "Maple"}]
+        with patch.object(
+            self.service,
+            "fetch_all_properties",
+            side_effect=UpstreamUnavailable("upstream down"),
+        ) as fetch_mock:
+            with self.assertRaises(UpstreamUnavailable):
+                self.service.refresh_cache()
+            # Follower arriving within the coalesce window returns silently
+            # rather than re-attempting the failed fetch.
+            self.service.refresh_cache()
+
+        self.assertEqual(fetch_mock.call_count, 1)
+        self.assertEqual(self.service.cache, [{"id": "prop-1", "name": "Maple"}])
+
     def test_get_cached_properties_returns_copy(self):
         self.service.cache = [{"id": "prop-1", "nested": {"a": 1}}]
 

--- a/test_generated_matrices.py
+++ b/test_generated_matrices.py
@@ -43,6 +43,14 @@ class GeneratedRouteMatrixTestCase(unittest.TestCase):
         with self.services.properties.cache_lock:
             self.original_cache = copy.deepcopy(self.services.properties.cache)
             self.services.properties.cache = []
+        # The PropertyService is shared across this whole test class.
+        # refresh_cache coalesces back-to-back calls inside a small window
+        # to suppress upstream fanout storms; in this test suite that means
+        # the Nth test would see the (N-1)th test's timestamp and skip its
+        # own refresh, leaving the seeded property in cache and changing
+        # which template branch renders. Reset the coalesce timestamp so
+        # each test starts from a clean "no recent refresh" state.
+        self.services.properties._last_refresh_monotonic = 0.0
         self.original_google_client_id = self.services.config.google_client_id
         self.original_google_client_secret = self.services.config.google_client_secret
         self.seed_property()


### PR DESCRIPTION
## Summary

The synchronous cache refresh on `/for-rent` and `/for-rent.json` was firing one full upstream fanout (id listing + per-property details/photos in an 8-way thread pool) per concurrent request, which multiplied AWS API Gateway / Lambda load N-fold on any small traffic burst — directly working against the cost-reduction goal that the periodic refresher was removed for (`somewheria_app/__init__.py:230`).

`refresh_cache` now serializes on a dedicated lock and short-circuits any caller arriving within `REFRESH_COALESCE_SECONDS` (2s) of the previous attempt. The leader does the work; queued followers see the just-updated timestamp and skip their own fetch. The timestamp is recorded on both success **and** failure, so an upstream outage doesn't cause every queued request to serially re-hit the dead endpoint — the route's existing `UpstreamUnavailable` fallback continues to serve the cache transparently.

Net effect on a 5-way burst: upstream load drops from 5× to 1×, with no change in user-visible latency.

## Changes
- `somewheria_app/services/properties.py`: add `_refresh_lock` / `_last_refresh_monotonic`, double-locked coalesce check in `refresh_cache`, attempt-time recorded on both success and failure.
- `test_coverage_full.py`: three new tests covering coalesce-within-window, refetch-after-window, and failure coalescing.
- `test_generated_matrices.py`: reset the coalesce timestamp in `setUp` because the suite shares one `PropertyService` across all tests and relied on each `/for-rent` hit triggering a fresh upstream attempt.

## Test plan
- [x] `python -m unittest discover` — 707 passed, 1 skipped
- [x] `ruff check .` — clean
- [ ] CI green on the PR before merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01VrHLtt44pWgSEoH9HKUPRk)_