### PR TITLE
Persist viewing-appointment bookings instead of just emailing them

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -121,11 +121,15 @@ def schedule_appointment(uuid):
     if not property_name:
         return jsonify(success=False, error="Property not found."), 404
 
+    iso_date = requested_date.isoformat()
+    if not services.appointments.book(uuid, iso_date):
+        return jsonify(success=False, error="That date is already booked."), 409
+
     message = (
         "Appointment requested!\n\n"
         f"Property: {property_name}\n"
         f"Requested by: {name}\n"
-        f"For date: {date}\n"
+        f"For date: {iso_date}\n"
         f"Contact method: {contact_method}\n"
         f"Contact info: {contact_info}\n"
         f"Requested at: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"

--- a/somewheria_app/services/appointments.py
+++ b/somewheria_app/services/appointments.py
@@ -11,7 +11,9 @@ class AppointmentService:
         self.logger = get_console_logger("appointments")
         # Serialize reads/writes against the appointments file so concurrent
         # save() calls cannot interleave and corrupt the line-oriented data.
-        self._lock = threading.Lock()
+        # Reentrant so book() can hold the lock across a load+save round-trip
+        # without deadlocking on its own nested load()/save() calls.
+        self._lock = threading.RLock()
 
     def print_check_file(self, path, purpose: str) -> None:
         abs_path = path.resolve()
@@ -63,3 +65,17 @@ class AppointmentService:
                     pass
                 raise
         self.print_check_file(self.config.property_appointments_file, "Appointments saved")
+
+    def book(self, property_id: str, iso_date: str) -> bool:
+        # Returns True when the booking was newly recorded, False when the
+        # date was already taken for that property. Load+save run under the
+        # same lock so a second caller cannot squeeze in between and produce
+        # a double-booking on the same property/date.
+        with self._lock:
+            appointments = self.load()
+            booked = appointments.setdefault(property_id, set())
+            if iso_date in booked:
+                return False
+            booked.add(iso_date)
+            self.save(appointments)
+            return True

--- a/test_generated_matrices.py
+++ b/test_generated_matrices.py
@@ -120,6 +120,7 @@ class GeneratedRouteMatrixTestCase(unittest.TestCase):
                 stack.enter_context(patch.object(self.services.properties, "toggle_sale"))
             if path == "/property/prop-1/schedule":
                 stack.enter_context(patch.object(self.services.properties, "fetch_live_property_name", return_value="Maple House"))
+                stack.enter_context(patch.object(self.services.appointments, "book", return_value=True))
                 stack.enter_context(patch.object(self.services.notifications, "send_email"))
             if path == "/google/login":
                 self.services.config.google_client_id = "client-id"

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -261,6 +261,8 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
     def test_schedule_appointment_success_sends_email(self):
         future_date = (datetime.date.today() + datetime.timedelta(days=5)).isoformat()
         with patch.object(self.services.properties, "fetch_live_property_name", return_value="Maple House"), patch.object(
+            self.services.appointments, "book", return_value=True
+        ), patch.object(
             self.services.notifications,
             "send_email",
         ) as send_email_mock:
@@ -279,6 +281,43 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         send_email_mock.assert_called_once()
         self.assertIn("Viewing Appointment Request", send_email_mock.call_args[0][0])
         self.assertIn("Maple House", send_email_mock.call_args[0][1])
+
+    def test_schedule_appointment_persists_booking(self):
+        future_date = (datetime.date.today() + datetime.timedelta(days=5)).isoformat()
+        with patch.object(self.services.properties, "fetch_live_property_name", return_value="Maple House"), patch.object(
+            self.services.appointments, "book", return_value=True
+        ) as book_mock, patch.object(self.services.notifications, "send_email"):
+            response = self.client.post(
+                "/property/prop-1/schedule",
+                json={
+                    "name": "Alex",
+                    "date": future_date,
+                    "contact_method": "email",
+                    "contact_info": "alex@example.com",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        book_mock.assert_called_once_with("prop-1", future_date)
+
+    def test_schedule_appointment_rejects_double_booking(self):
+        future_date = (datetime.date.today() + datetime.timedelta(days=5)).isoformat()
+        with patch.object(self.services.properties, "fetch_live_property_name", return_value="Maple House"), patch.object(
+            self.services.appointments, "book", return_value=False
+        ), patch.object(self.services.notifications, "send_email") as send_email_mock:
+            response = self.client.post(
+                "/property/prop-1/schedule",
+                json={
+                    "name": "Alex",
+                    "date": future_date,
+                    "contact_method": "email",
+                    "contact_info": "alex@example.com",
+                },
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.get_json()["error"], "That date is already booked.")
+        send_email_mock.assert_not_called()
 
     def test_about_page_loads(self):
         response = self.client.get("/about")

--- a/test_services.py
+++ b/test_services.py
@@ -306,6 +306,25 @@ class AppointmentServiceTestCase(unittest.TestCase):
         self.assertEqual(loaded["prop-1"], {"2030-01-10", "2030-01-11"})
         self.assertEqual(loaded["prop-2"], {"2030-02-01"})
 
+    def test_book_persists_new_appointment(self):
+        self.assertTrue(self.service.book("prop-1", "2030-05-01"))
+        loaded = self.service.load()
+        self.assertEqual(loaded["prop-1"], {"2030-05-01"})
+
+    def test_book_rejects_double_booking(self):
+        self.assertTrue(self.service.book("prop-1", "2030-05-01"))
+        self.assertFalse(self.service.book("prop-1", "2030-05-01"))
+        loaded = self.service.load()
+        self.assertEqual(loaded["prop-1"], {"2030-05-01"})
+
+    def test_book_accumulates_distinct_dates(self):
+        self.assertTrue(self.service.book("prop-1", "2030-05-01"))
+        self.assertTrue(self.service.book("prop-1", "2030-05-02"))
+        self.assertTrue(self.service.book("prop-2", "2030-05-01"))
+        loaded = self.service.load()
+        self.assertEqual(loaded["prop-1"], {"2030-05-01", "2030-05-02"})
+        self.assertEqual(loaded["prop-2"], {"2030-05-01"})
+
 
 class PropertyServiceTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Fixes a real broken feature: viewing-appointment requests were emailed but never persisted, so the frontend's "this date is already booked" guard never had any data to enforce against.

- `docs/RUNBOOK.md` and `docs/ADMIN_GUIDE.md` both document `property_appointments.txt` as the durable record of viewing requests.
- `/property/<uuid>` already loads `booked_dates` from `AppointmentService` to feed the duplicate-date check in `templates/property_details.html` (line 471, then line 656).
- But `schedule_appointment` in `somewheria_app/routes/public_routes.py` only called `notifications.send_email(...)` — `appointments.save()` was never reached from anywhere in the app. `booked_dates` was always empty for every property.

## Changes

- Added `AppointmentService.book(property_id, iso_date)` that holds the service lock across a `load`+`save` round-trip and reports whether the booking was newly recorded. The lock is upgraded from `Lock` to `RLock` so the nested `load`/`save` acquisitions don't deadlock.
- `schedule_appointment` now calls `book()` after validating inputs. If the date is already taken it returns `409` with `"That date is already booked."` and the admin email is suppressed — only genuinely new bookings notify.
- New unit tests in `test_services.py` cover the persist / double-book / multi-date behavior of `book()`.
- New route tests in `test_routes_expanded.py` cover the persistence call and the 409 double-booking response. The existing success test (and the route matrix in `test_generated_matrices.py`) now patches `appointments.book` so the suite no longer leaves a real `property_appointments.txt` in the repo root.

## Test plan

- [x] `python -m unittest discover` — 712 tests, all pass
- [x] `ruff check .` — clean
- [x] Verified the test run no longer drops a stray `property_appointments.txt` in the working directory

---
_Generated by [Claude Code](https://claude.ai/code/session_015LkdUQT8tCmqy3mfuYakKn)_