### PR TITLE
Stop double-logging property mutations in admin routes

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -81,16 +81,8 @@ def save_edit(id):
     try:
         if id == "new":
             services.properties.create_property(request.form, actor_email)
-            try:
-                services.notifications.log_site_change(actor_email, "property_created", {"id_or_new": id})
-            except Exception:
-                pass
             return redirect(url_for("manage_listings"))
         services.properties.update_property(id, request.form, actor_email)
-        try:
-            services.notifications.log_site_change(actor_email, "property_updated", {"id": id})
-        except Exception:
-            pass
         return redirect(url_for("manage_listings"))
     except KeyError:
         return "Property not found", 404
@@ -123,10 +115,6 @@ def upload_image(uuid):
             "Upload Error", f"Unexpected upload failure for {uuid}: {exc}"
         )
         return jsonify(success=False, message="Upload failed."), 500
-    try:
-        services.notifications.log_site_change(actor_email, "property_image_uploaded", {"id": uuid, "url": relative_url})
-    except Exception:
-        pass
     return jsonify(success=True, new_image_url=relative_url)
 
 
@@ -843,10 +831,6 @@ def delete_listing(id):
     actor_email = (get_current_user() or {}).get("email", "anonymous") if is_logged_in() else "anonymous"
     try:
         services.properties.delete_property(id, actor_email)
-        try:
-            services.notifications.log_site_change(actor_email, "property_deleted", {"id": id})
-        except Exception:
-            pass
         return redirect(url_for("manage_listings"))
     except Exception as exc:
         services.notifications.log_and_notify_error(
@@ -862,10 +846,6 @@ def toggle_sale(id):
     actor_email = (get_current_user() or {}).get("email", "anonymous") if is_logged_in() else "anonymous"
     try:
         services.properties.toggle_sale(id, actor_email)
-        try:
-            services.notifications.log_site_change(actor_email, "property_for_sale_toggled", {"id": id})
-        except Exception:
-            pass
         return redirect(url_for("manage_listings"))
     except KeyError:
         return "Property not found", 404

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -851,6 +851,36 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn("/manage-listings", response.headers["Location"])
         toggle_sale_mock.assert_called_once_with("prop-1", "admin@example.com")
 
+    def test_property_routes_do_not_double_log_site_change(self):
+        # The property service layer already calls log_site_change for create,
+        # update, delete, toggle-sale, and image upload. The route layer used
+        # to call it a second time, inflating site_changes.log and
+        # double-counting created/deleted events in recent_listing_activity
+        # (which feeds the admin dashboard chart). Guard against the
+        # regression by verifying no log_site_change calls originate from the
+        # routes themselves when the service methods are mocked out.
+        self.login_as("admin", email="admin@example.com")
+        with patch.object(self.services.properties, "create_property"), patch.object(
+            self.services.properties, "update_property"
+        ), patch.object(self.services.properties, "delete_property"), patch.object(
+            self.services.properties, "toggle_sale"
+        ), patch.object(
+            self.services.properties, "upload_image", return_value="/static/uploads/x.jpg"
+        ), patch.object(
+            self.services.notifications, "log_site_change"
+        ) as log_mock:
+            self.client.post("/save-edit/new", data={"name": "Maple"})
+            self.client.post("/save-edit/prop-1", data={"name": "Maple"})
+            self.client.post("/delete-listing/prop-1")
+            self.client.post("/toggle-sale/prop-1")
+            self.client.post(
+                "/upload-image/prop-1",
+                data={"file": (BytesIO(b"image"), "photo.png")},
+                content_type="multipart/form-data",
+            )
+
+        log_mock.assert_not_called()
+
     def test_google_callback_shows_oauth_error_screen_when_not_configured(self):
         self.services.config.google_client_id = ""
         self.services.config.google_client_secret = ""


### PR DESCRIPTION
## Summary

Property mutation routes (`/save-edit/<id>`, `/delete-listing/<id>`, `/toggle-sale/<id>`, `/upload-image/<uuid>`) each called `notifications.log_site_change` from the route handler **on top of** the existing call inside the property service layer. Concrete effects:

- For create/update/delete: the action name on both call sites was identical (`property_created`, `property_updated`, `property_deleted`) — so each mutation produced two JSONL rows in `site_changes.log`, and `AnalyticsTracker.recent_listing_activity` (which feeds the **Listings by Month** chart on the admin dashboard) reported double the real counts.
- For toggle-sale and upload-image: the route used a divergent action name (`property_for_sale_toggled`, `property_image_uploaded`) from the service (`property_toggle_sale`, `image_added`), creating two distinct rows per event and making the change log harder to scan.

The service-layer entries are the more useful ones — they carry the resolved `property_id` (the route's `id_or_new` was always literally the string `"new"` for create) and they're guaranteed to fire only on a successful upstream apply.

### Changes

- `somewheria_app/routes/admin_routes.py`: removed the redundant `log_site_change` call from `save_edit` (create + update branches), `upload_image`, `delete_listing`, and `toggle_sale`. The service-layer call inside `PropertyService.{create,update,delete}_property`, `toggle_sale`, and `upload_image` remains the single source of truth.
- `test_routes_expanded.py`: added `test_property_routes_do_not_double_log_site_change` — mocks the property service methods and asserts no `log_site_change` calls originate from the routes themselves, guarding against re-introduction.

## Test plan

- [x] `python -m unittest discover` — 708 tests pass (was 707; added one regression test)
- [x] `ruff check .` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_015qvHPNWjnJ82SPWogFW3Bo)_