### PR TITLE
Standardize remaining timestamps on UTC ISO 8601

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -16,6 +16,7 @@ from ..services.auth import (
 from ..services.properties import BLANK_PROPERTY, UploadValidationError
 from ..services.registry import get_services
 from ..services.security import rate_limit
+from ..services.timeutil import utcnow_iso
 from ..services.validation import is_valid_email
 
 
@@ -698,7 +699,7 @@ def admin_contracts():
                             "end_date": end_date,
                             "status": status,
                             "pdf_filename": pdf_filename,
-                            "created_at": datetime.datetime.now().isoformat(),
+                            "created_at": utcnow_iso(),
                         }
                     )
                     services.storage.save_renter_contracts(contracts_data)

--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -9,6 +9,7 @@ from ..services.auth import (
 )
 from ..services.registry import get_services
 from ..services.security import rate_limit
+from ..services.timeutil import utcnow_iso
 from ..services.validation import is_valid_email
 
 
@@ -143,7 +144,7 @@ def schedule_appointment(uuid):
         f"For date: {iso_date}\n"
         f"Contact method: {contact_method}\n"
         f"Contact info: {contact_info}\n"
-        f"Requested at: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+        f"Requested at: {utcnow_iso()}"
     )
     services.notifications.send_email("Viewing Appointment Request", message)
     return jsonify(success=True)
@@ -196,7 +197,7 @@ def submit_lead_capture():
     added = services.storage.add_pending_lead_capture(
         {
             "email": email,
-            "submitted_at": datetime.datetime.now().isoformat(),
+            "submitted_at": utcnow_iso(),
         }
     )
     # Only notify admins on a genuinely new lead. Repeated submissions of an

--- a/somewheria_app/services/notifications.py
+++ b/somewheria_app/services/notifications.py
@@ -1,5 +1,4 @@
 import collections
-import datetime
 import html
 import json
 import re
@@ -7,6 +6,7 @@ import smtplib
 from email.message import EmailMessage
 
 from .console import get_console_logger
+from .timeutil import utcnow_iso
 from .validation import is_valid_email
 
 
@@ -106,7 +106,11 @@ class NotificationService:
     def log_site_change(self, user_email: str, action: str, extra: dict | None = None) -> None:
         try:
             entry = {
-                "timestamp": datetime.datetime.now().isoformat(),
+                # UTC so analytics.recent_listing_activity buckets entries by
+                # the same calendar month regardless of the server's local
+                # timezone — a naive local-time isoformat() looks UTC-shaped
+                # but silently drifts buckets across the midnight boundary.
+                "timestamp": utcnow_iso(),
                 "user": user_email or "anonymous",
                 "action": action,
                 "extra": extra or {},

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -9,7 +9,6 @@ The service is intentionally small and synchronous — it mirrors the
 
 from __future__ import annotations
 
-import datetime
 import os
 import secrets
 import threading
@@ -27,6 +26,7 @@ from .properties import (
     UploadValidationError,
     _ensure_safe_image_dimensions,
 )
+from .timeutil import utcnow_iso
 from .validation import is_valid_email
 
 
@@ -64,16 +64,11 @@ MAX_CONTACT_LEN = 200
 MAX_NAME_LEN = 120
 
 
-def _now_iso() -> str:
-    # ``datetime.utcnow()`` is deprecated in Python 3.12+; use an aware UTC
-    # now and strip the tzinfo so the wire format stays a bare
-    # ``YYYY-MM-DDTHH:MM:SSZ`` string identical to what older tickets carry.
-    return (
-        datetime.datetime.now(datetime.timezone.utc)
-        .replace(microsecond=0, tzinfo=None)
-        .isoformat()
-        + "Z"
-    )
+# Thin alias for backwards compatibility — call sites inside this module
+# already use ``_now_iso``; the implementation lives in services.timeutil
+# so notifications/log entries and contract/lead timestamps stay on the
+# same UTC wire format.
+_now_iso = utcnow_iso
 
 
 class TicketService:

--- a/somewheria_app/services/timeutil.py
+++ b/somewheria_app/services/timeutil.py
@@ -1,0 +1,31 @@
+"""Shared time helpers.
+
+Anything that writes a wire-format timestamp (JSONL change log, ticket
+records, contract metadata, lead-capture submissions, outgoing email
+bodies, …) routes through :func:`utcnow_iso` so timestamps stay
+consistent across the codebase. ``datetime.datetime.now()`` returns a
+naive local-clock value whose textual ``isoformat()`` looks identical to
+a UTC string but isn't — which silently misbuckets entries in
+``AnalyticsTracker.recent_listing_activity`` when the server's local
+date and UTC date straddle midnight.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+
+def utcnow_iso() -> str:
+    """Return current UTC time as ``YYYY-MM-DDTHH:MM:SSZ``.
+
+    Microseconds are dropped so the wire format is compact and identical
+    to what older ticket records carry — keeping the JSONL change log
+    grep-friendly and making the ``ts[:7]`` month-bucket slice in
+    :meth:`AnalyticsTracker.recent_listing_activity` correct.
+    """
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0, tzinfo=None)
+        .isoformat()
+        + "Z"
+    )

--- a/test_services.py
+++ b/test_services.py
@@ -1345,6 +1345,62 @@ class TicketsNowIsoTestCase(unittest.TestCase):
         self.assertLessEqual(delta, 2)
 
 
+class TimeUtilTestCase(unittest.TestCase):
+    """Lock the shared UTC timestamp helper.
+
+    Everything that writes a wire-format timestamp (tickets, the JSONL change
+    log, contract metadata, lead-capture submissions, …) routes through
+    ``utcnow_iso``. The ``YYYY-MM-DDTHH:MM:SSZ`` shape is part of the contract
+    AnalyticsTracker.recent_listing_activity relies on (it slices ``ts[:7]``
+    for the month bucket).
+    """
+
+    def test_utcnow_iso_is_seconds_precision_utc_z(self):
+        import datetime as _dt
+        from somewheria_app.services.timeutil import utcnow_iso
+
+        value = utcnow_iso()
+        self.assertEqual(len(value), 20)
+        self.assertTrue(value.endswith("Z"))
+        parsed = _dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        now_utc = _dt.datetime.now(_dt.timezone.utc).replace(tzinfo=None, microsecond=0)
+        self.assertLessEqual(abs((parsed - now_utc).total_seconds()), 2)
+
+    def test_tickets_now_iso_routes_through_shared_helper(self):
+        # The previous bug split timestamp generation across two helpers; if
+        # tickets ever re-introduces its own implementation, this guard fails
+        # loud so the change-log/recent_listing_activity bucket logic doesn't
+        # silently regress.
+        from somewheria_app.services import tickets, timeutil
+
+        self.assertIs(tickets._now_iso, timeutil.utcnow_iso)
+
+
+class NotificationsChangeLogTimestampTestCase(unittest.TestCase):
+    def test_log_site_change_writes_utc_z_timestamp(self):
+        # Naive local-time isoformat() looks UTC-shaped but isn't, so
+        # AnalyticsTracker.recent_listing_activity buckets entries by the
+        # wrong calendar month when the server's local date and UTC date
+        # straddle midnight. The change-log writer must emit Z-suffixed UTC.
+        import json as _json
+
+        config = SimpleNamespace(change_log_file=Path("/tmp/test_change_log.log"))
+        analytics = Mock()
+        service = NotificationService(config, analytics)
+        handle = mock_open()
+        with patch.object(Path, "open", handle):
+            service.log_site_change("admin@example.com", "property_created", {"id": "p1"})
+
+        written = "".join(call.args[0] for call in handle().write.call_args_list).strip()
+        entry = _json.loads(written)
+        self.assertTrue(
+            entry["timestamp"].endswith("Z"),
+            f"timestamp not Z-suffixed UTC: {entry['timestamp']!r}",
+        )
+        # ``ts[:7]`` is the YYYY-MM slice recent_listing_activity uses.
+        self.assertRegex(entry["timestamp"][:7], r"^\d{4}-\d{2}$")
+
+
 class EmailValidationTestCase(unittest.TestCase):
     def test_accepts_typical_addresses(self):
         for value in (


### PR DESCRIPTION
## Summary

Four call sites still wrote timestamps with naive `datetime.datetime.now()`, producing local-clock `isoformat()` strings that look UTC-shaped but silently drift across the local/UTC midnight boundary. The JSONL change log is the most visible victim: `AnalyticsTracker.recent_listing_activity` slices `ts[:7]` for the month bucket, so a `property_created` event recorded just before/after local midnight gets attributed to the wrong calendar month relative to the rest of the (already UTC-aware) codebase.

Promoted the existing `tickets._now_iso` helper into a small `services/timeutil` module (`utcnow_iso`) and routed the four remaining call sites through it:

- `NotificationService.log_site_change` — change log timestamp (the bucketing bug above)
- `admin_routes.admin_contracts` — contract `created_at`
- `public_routes.submit_lead_capture` — lead-capture `submitted_at`
- `public_routes.schedule_appointment` — "Requested at:" line in appointment email body

`tickets._now_iso` is kept as a thin alias so existing call sites and the format-pinning `TicketsNowIsoTestCase` continue to work.

Completes the cleanup started in eae7bf6 (`Replace deprecated datetime.utcnow() with timezone-aware UTC clock`), which moved `utcnow()` but left naive `now()` calls behind.

## Test plan
- [x] `python -m unittest discover` — 738 tests pass
- [x] `ruff check .` — clean
- [x] New `TimeUtilTestCase` pins the `YYYY-MM-DDTHH:MM:SSZ` shape and asserts `tickets._now_iso is timeutil.utcnow_iso`
- [x] New `NotificationsChangeLogTimestampTestCase` verifies the change-log writer emits a Z-suffixed UTC timestamp so the `ts[:7]` month-bucket slice in `recent_listing_activity` stays correct


---
_Generated by [Claude Code](https://claude.ai/code/session_015cFkuhkjHc5ubrntfhYxjU)_