### PR TITLE
Fix lost-update race in JSON storage and TicketService

### DIFF
--- a/somewheria_app/services/sql_storage.py
+++ b/somewheria_app/services/sql_storage.py
@@ -14,6 +14,7 @@ as a routing key — ``config.tickets_file`` routes to the ``tickets`` table.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import tempfile
@@ -28,6 +29,18 @@ class SqlStorageService:
         self.config = config
         self.logger = get_console_logger("storage-sql")
         self.db = Database(config.sqlite_file)
+
+    @contextlib.contextmanager
+    def atomic(self):
+        """No-op context manager mirroring FileStorageService.atomic().
+
+        SQL writes already go through ``db.transaction()`` so a load+save
+        wrapper isn't required for correctness. Callers (TicketService et
+        al.) use ``with storage.atomic():`` without branching on backend;
+        that boils down to a real RLock under the file backend and to this
+        pass-through here.
+        """
+        yield
 
     # ---------------------------------------------------------------- helpers
 

--- a/somewheria_app/services/storage.py
+++ b/somewheria_app/services/storage.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import tempfile
@@ -9,8 +10,26 @@ from .console import get_console_logger
 class FileStorageService:
     def __init__(self, config) -> None:
         self.config = config
-        self.file_lock = threading.Lock()
+        # Re-entrant so callers can wrap a load+modify+save sequence in
+        # ``with storage.atomic():`` and still call ``load_json_file`` /
+        # ``save_json_file`` (which each acquire the lock) inside the block.
+        # Without atomic load+save, two threads doing read-modify-write on the
+        # same file silently lose one update — verified: 50 concurrent
+        # ``add_pending_registration`` calls under the old plain Lock kept
+        # only ~8 entries on disk.
+        self.file_lock = threading.RLock()
         self.logger = get_console_logger("storage")
+
+    @contextlib.contextmanager
+    def atomic(self):
+        """Hold the storage lock across a multi-step read-modify-write.
+
+        SqlStorageService exposes the same context manager (as a no-op,
+        since its writes already go through real transactions) so callers
+        can rely on this API without branching on the backend.
+        """
+        with self.file_lock:
+            yield
 
     def load_json_file(self, path, default, *, expected_type: type | tuple[type, ...] | None = None):
         try:
@@ -68,40 +87,48 @@ class FileStorageService:
         the route) keeps a repeated submission from bloating the file or
         triggering a second admin notification, mirroring
         ``add_pending_lead_capture`` and the SQL backend's idempotency.
+
+        The load+save runs under ``self.file_lock`` so two concurrent
+        submissions cannot both load the pre-write list and then race each
+        other's saves (which would silently drop one entry).
         """
-        registrations = self.get_pending_registrations()
-        target_email = (registration.get("email") or "").strip().lower()
-        if target_email and any(
-            (item.get("email") or "").lower() == target_email for item in registrations
-        ):
-            return False
-        registrations.append(registration)
-        self.save_json_file(self.config.registration_file, registrations)
-        return True
+        with self.file_lock:
+            registrations = self.get_pending_registrations()
+            target_email = (registration.get("email") or "").strip().lower()
+            if target_email and any(
+                (item.get("email") or "").lower() == target_email for item in registrations
+            ):
+                return False
+            registrations.append(registration)
+            self.save_json_file(self.config.registration_file, registrations)
+            return True
 
     def remove_pending_registration(self, email: str) -> None:
-        registrations = [
-            item for item in self.get_pending_registrations() if item.get("email", "").lower() != email.lower()
-        ]
-        self.save_json_file(self.config.registration_file, registrations)
+        with self.file_lock:
+            registrations = [
+                item for item in self.get_pending_registrations() if item.get("email", "").lower() != email.lower()
+            ]
+            self.save_json_file(self.config.registration_file, registrations)
 
     def get_user_roles(self) -> dict:
         return self.load_json_file(self.config.user_roles_file, {}, expected_type=dict)
 
     def set_user_role(self, email: str, role: str) -> None:
-        roles = self.get_user_roles()
-        roles[email.lower()] = role
-        self.save_json_file(self.config.user_roles_file, roles)
+        with self.file_lock:
+            roles = self.get_user_roles()
+            roles[email.lower()] = role
+            self.save_json_file(self.config.user_roles_file, roles)
 
     def delete_user_role(self, email: str) -> bool:
         email = email.lower()
-        roles = self.get_user_roles()
-        previous = roles.get(email)
-        # Store a tombstone ("revoked") instead of removing the key outright
-        # so that env-var fallbacks in AuthService.get_user_role cannot
-        # silently restore a deleted user's access on their next login.
-        roles[email] = "revoked"
-        self.save_json_file(self.config.user_roles_file, roles)
+        with self.file_lock:
+            roles = self.get_user_roles()
+            previous = roles.get(email)
+            # Store a tombstone ("revoked") instead of removing the key outright
+            # so that env-var fallbacks in AuthService.get_user_role cannot
+            # silently restore a deleted user's access on their next login.
+            roles[email] = "revoked"
+            self.save_json_file(self.config.user_roles_file, roles)
         return previous is not None and previous != "revoked"
 
     def get_renter_profiles(self) -> dict:
@@ -118,22 +145,26 @@ class FileStorageService:
         # rejected as a duplicate. The caller uses the return value to decide
         # whether to fire the "new lead" admin email — without that gate a
         # repeated submission of an already-pending address spams the inbox.
-        leads = self.get_pending_lead_captures()
-        # De-duplicate by email so a repeated submission doesn't bloat the file
-        # or give the requester a way to flood the admin UI.
-        target_email = (lead.get("email") or "").lower()
-        if target_email and any(item.get("email", "").lower() == target_email for item in leads):
-            return False
-        leads.append(lead)
-        self.save_json_file(self.config.lead_capture_file, leads)
-        return True
+        # Load+save runs under the file lock so two concurrent submissions
+        # can't both pass the dedup check and then race each other's saves.
+        with self.file_lock:
+            leads = self.get_pending_lead_captures()
+            # De-duplicate by email so a repeated submission doesn't bloat the file
+            # or give the requester a way to flood the admin UI.
+            target_email = (lead.get("email") or "").lower()
+            if target_email and any(item.get("email", "").lower() == target_email for item in leads):
+                return False
+            leads.append(lead)
+            self.save_json_file(self.config.lead_capture_file, leads)
+            return True
 
     def remove_pending_lead_capture(self, email: str) -> None:
-        leads = [
-            item for item in self.get_pending_lead_captures()
-            if item.get("email", "").lower() != email.lower()
-        ]
-        self.save_json_file(self.config.lead_capture_file, leads)
+        with self.file_lock:
+            leads = [
+                item for item in self.get_pending_lead_captures()
+                if item.get("email", "").lower() != email.lower()
+            ]
+            self.save_json_file(self.config.lead_capture_file, leads)
 
     def get_renter_contracts(self) -> dict:
         return self.load_json_file(self.config.contracts_file, {}, expected_type=dict)

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -191,9 +191,14 @@ class TicketService:
             "notes": [],
         }
 
-        tickets = self._load()
-        tickets.append(ticket)
-        self._save(tickets)
+        # Hold the storage lock across load+append+save so a second
+        # ``create_ticket`` racing this one cannot load the same pre-append
+        # list, then save back over our just-saved row — a plain load/save
+        # pair on the file backend silently loses one ticket per collision.
+        with self.storage.atomic():
+            tickets = self._load()
+            tickets.append(ticket)
+            self._save(tickets)
 
         try:
             # Notify the internal admin inbox.
@@ -304,13 +309,14 @@ class TicketService:
             return None
         # Persist the JIRA key onto the ticket so the admin UI can deep-link
         # and the webhook can map JIRA events back to the local ticket.
-        tickets = self._load()
-        for stored in tickets:
-            if stored.get("id") == ticket_id:
-                stored["jira_key"] = key
-                stored["updated_at"] = _now_iso()
-                self._save(tickets)
-                break
+        with self.storage.atomic():
+            tickets = self._load()
+            for stored in tickets:
+                if stored.get("id") == ticket_id:
+                    stored["jira_key"] = key
+                    stored["updated_at"] = _now_iso()
+                    self._save(tickets)
+                    break
         return key
 
     def find_by_jira_key(self, jira_key: str) -> dict | None:
@@ -322,23 +328,24 @@ class TicketService:
         return None
 
     def set_email_updates(self, ticket_id: str, enabled: bool, actor_email: str) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            ticket["email_updates"] = bool(enabled)
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_email_updates_toggled",
-                    {"ticket_id": ticket_id, "enabled": bool(enabled)},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        with self.storage.atomic():
+            tickets = self._load()
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket["email_updates"] = bool(enabled)
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                try:
+                    self.notifications.log_site_change(
+                        actor_email or "unknown",
+                        "ticket_email_updates_toggled",
+                        {"ticket_id": ticket_id, "enabled": bool(enabled)},
+                    )
+                except Exception:
+                    pass
+                return ticket
+            return None
 
     # Send the email when ``email_updates`` is on AND we actually have a
     # reachable submitter address. The NotificationService itself will no-op
@@ -360,67 +367,77 @@ class TicketService:
         updates: dict,
         actor_email: str,
     ) -> dict | None:
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            changed: dict = {}
+        # Hold the storage lock only across load+modify+save. Side-effect
+        # notifications (email + change log) run outside the lock so a slow
+        # SMTP send can't stall other ticket operations.
+        target: dict | None = None
+        changed: dict = {}
+        with self.storage.atomic():
+            tickets = self._load()
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                target = ticket
 
-            if "status" in updates:
-                status = (updates.get("status") or "").strip().lower()
-                if status in ALLOWED_STATUSES and status != ticket.get("status"):
-                    ticket["status"] = status
-                    changed["status"] = status
+                if "status" in updates:
+                    status = (updates.get("status") or "").strip().lower()
+                    if status in ALLOWED_STATUSES and status != ticket.get("status"):
+                        ticket["status"] = status
+                        changed["status"] = status
 
-            if "priority" in updates:
-                priority = (updates.get("priority") or "").strip().lower()
-                if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
-                    ticket["priority"] = priority
-                    changed["priority"] = priority
+                if "priority" in updates:
+                    priority = (updates.get("priority") or "").strip().lower()
+                    if priority in ALLOWED_PRIORITIES and priority != ticket.get("priority"):
+                        ticket["priority"] = priority
+                        changed["priority"] = priority
 
-            if "assigned_to" in updates:
-                assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
-                if assignee != ticket.get("assigned_to"):
-                    ticket["assigned_to"] = assignee
-                    changed["assigned_to"] = assignee
+                if "assigned_to" in updates:
+                    assignee = (updates.get("assigned_to") or "").strip().lower()[:254]
+                    if assignee != ticket.get("assigned_to"):
+                        ticket["assigned_to"] = assignee
+                        changed["assigned_to"] = assignee
 
-            if not changed:
-                return ticket
+                if changed:
+                    ticket["updated_at"] = _now_iso()
+                    self._save(tickets)
+                break
 
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
+        if target is None:
+            return None
+        if not changed:
+            return target
 
-            # Email the submitter a summary of what changed.
-            friendly_bits = []
-            if "status" in changed:
-                friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
-            if "priority" in changed:
-                friendly_bits.append(f"Severity: {changed['priority']}")
-            if "assigned_to" in changed:
-                friendly_bits.append(
-                    f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
-                )
-            self._maybe_email_submitter(
-                ticket,
-                subject=f"Repair ticket update: {ticket.get('title', '')}",
-                body=(
-                    f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                    f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
-                    + "\n".join(friendly_bits)
-                    + "\n\nYou can view the full ticket in the Somewheria portal."
-                ),
+        # Email the submitter a summary of what changed.
+        ticket = target
+        friendly_bits = []
+        if "status" in changed:
+            friendly_bits.append(f"Status: {changed['status'].replace('_', ' ')}")
+        if "priority" in changed:
+            friendly_bits.append(f"Severity: {changed['priority']}")
+        if "assigned_to" in changed:
+            friendly_bits.append(
+                f"Assigned to: {changed['assigned_to'] or '(unassigned)'}"
             )
+        self._maybe_email_submitter(
+            ticket,
+            subject=f"Repair ticket update: {ticket.get('title', '')}",
+            body=(
+                f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
+                f"There's an update on your repair ticket (reference {ticket_id[:8]}):\n\n"
+                + "\n".join(friendly_bits)
+                + "\n\nYou can view the full ticket in the Somewheria portal."
+            ),
+        )
 
-            try:
-                self.notifications.log_site_change(
-                    actor_email or "unknown",
-                    "ticket_updated",
-                    {"ticket_id": ticket_id, **changed},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor_email or "unknown",
+                "ticket_updated",
+                {"ticket_id": ticket_id, **changed},
+            )
+        except Exception:
+            pass
+        return ticket
 
     def add_photo(self, ticket_id: str, uploaded_file, actor_email: str) -> dict | None:
         """Validate ``uploaded_file`` (same checks as listing-photo uploads:
@@ -455,67 +472,76 @@ class TicketService:
         except Exception as exc:
             raise UploadValidationError("File is not a valid image.") from exc
 
-        tickets = self._load()
-        target = None
-        for ticket in tickets:
-            if ticket.get("id") == ticket_id:
-                target = ticket
-                break
-        if target is None:
-            return None
+        # Hold the storage lock across the load → limit check → binary
+        # save → tickets save sequence so two concurrent uploads to the
+        # same ticket cannot both pass the MAX_TICKET_PHOTOS check on a
+        # stale count, nor race each other's tickets.json save (which on
+        # the file backend silently drops one upload's metadata).
+        relative_url: str | None = None
+        target_snapshot: dict | None = None
+        with self.storage.atomic():
+            tickets = self._load()
+            target = None
+            for ticket in tickets:
+                if ticket.get("id") == ticket_id:
+                    target = ticket
+                    break
+            if target is None:
+                return None
 
-        existing_photos = target.get("photos") or []
-        if not isinstance(existing_photos, list):
-            existing_photos = []
-        if len(existing_photos) >= MAX_TICKET_PHOTOS:
-            raise UploadValidationError(
-                f"Each ticket is limited to {MAX_TICKET_PHOTOS} photos."
-            )
-
-        # ticket_id is a uuid4 hex string from create_ticket(); guard anyway
-        # so a hand-edited tickets.json can't smuggle path separators.
-        safe_ticket_id = "".join(c for c in ticket_id if c.isalnum())[:64]
-        if not safe_ticket_id:
-            raise UploadValidationError("Invalid ticket id.")
-
-        ticket_dir = (self.config.ticket_upload_dir / safe_ticket_id).resolve()
-        upload_root = self.config.ticket_upload_dir.resolve()
-        try:
-            ticket_dir.relative_to(upload_root)
-        except ValueError as exc:
-            raise UploadValidationError("Invalid destination path.") from exc
-
-        new_filename = f"{secrets.token_hex(8)}.{ext}"
-        save_path = (ticket_dir / new_filename).resolve()
-        try:
-            save_path.relative_to(upload_root)
-        except ValueError as exc:
-            raise UploadValidationError("Invalid destination path.") from exc
-
-        ok = self.storage.save_binary_file(save_path, raw)
-        if not ok:
-            raise UploadValidationError("Failed to save photo.")
-
-        # Persist a relative URL so templates can render it as <img src=...>.
-        relative_url = f"/static/uploads/tickets/{safe_ticket_id}/{new_filename}"
-        existing_photos.append({"url": relative_url, "uploaded_at": _now_iso()})
-        target["photos"] = existing_photos
-        target["updated_at"] = _now_iso()
-        try:
-            self._save(tickets)
-        except Exception as exc:
-            # The photo is on disk but the ticket record never picked it up.
-            # Leaving it would orphan the file under static/uploads/tickets/
-            # forever — best-effort delete so the upload dir doesn't grow
-            # unboundedly on repeated save failures.
-            try:
-                self.storage.delete_file(save_path)
-            except Exception:
-                self.logger.warning(
-                    "Failed to clean up orphaned ticket photo %s", save_path
+            existing_photos = target.get("photos") or []
+            if not isinstance(existing_photos, list):
+                existing_photos = []
+            if len(existing_photos) >= MAX_TICKET_PHOTOS:
+                raise UploadValidationError(
+                    f"Each ticket is limited to {MAX_TICKET_PHOTOS} photos."
                 )
-            self.logger.error("Failed to persist ticket photos: %s", exc)
-            raise UploadValidationError("Failed to record photo on ticket.") from exc
+
+            # ticket_id is a uuid4 hex string from create_ticket(); guard anyway
+            # so a hand-edited tickets.json can't smuggle path separators.
+            safe_ticket_id = "".join(c for c in ticket_id if c.isalnum())[:64]
+            if not safe_ticket_id:
+                raise UploadValidationError("Invalid ticket id.")
+
+            ticket_dir = (self.config.ticket_upload_dir / safe_ticket_id).resolve()
+            upload_root = self.config.ticket_upload_dir.resolve()
+            try:
+                ticket_dir.relative_to(upload_root)
+            except ValueError as exc:
+                raise UploadValidationError("Invalid destination path.") from exc
+
+            new_filename = f"{secrets.token_hex(8)}.{ext}"
+            save_path = (ticket_dir / new_filename).resolve()
+            try:
+                save_path.relative_to(upload_root)
+            except ValueError as exc:
+                raise UploadValidationError("Invalid destination path.") from exc
+
+            ok = self.storage.save_binary_file(save_path, raw)
+            if not ok:
+                raise UploadValidationError("Failed to save photo.")
+
+            # Persist a relative URL so templates can render it as <img src=...>.
+            relative_url = f"/static/uploads/tickets/{safe_ticket_id}/{new_filename}"
+            existing_photos.append({"url": relative_url, "uploaded_at": _now_iso()})
+            target["photos"] = existing_photos
+            target["updated_at"] = _now_iso()
+            try:
+                self._save(tickets)
+            except Exception as exc:
+                # The photo is on disk but the ticket record never picked it up.
+                # Leaving it would orphan the file under static/uploads/tickets/
+                # forever — best-effort delete so the upload dir doesn't grow
+                # unboundedly on repeated save failures.
+                try:
+                    self.storage.delete_file(save_path)
+                except Exception:
+                    self.logger.warning(
+                        "Failed to clean up orphaned ticket photo %s", save_path
+                    )
+                self.logger.error("Failed to persist ticket photos: %s", exc)
+                raise UploadValidationError("Failed to record photo on ticket.") from exc
+            target_snapshot = target
 
         try:
             self.notifications.log_site_change(
@@ -525,61 +551,70 @@ class TicketService:
             )
         except Exception:
             pass
-        return target
+        return target_snapshot
 
     def add_note(self, ticket_id: str, text: str, actor_email: str) -> dict | None:
         text = (text or "").strip()[:MAX_NOTE_LEN]
         if not text:
             raise ValueError("Note cannot be empty.")
-        tickets = self._load()
-        for ticket in tickets:
-            if ticket.get("id") != ticket_id:
-                continue
-            actor = (actor_email or "unknown").lower()
-            ticket.setdefault("notes", []).append({
-                "at": _now_iso(),
-                "by": actor,
-                "text": text,
-            })
-            ticket["updated_at"] = _now_iso()
-            self._save(tickets)
+        # Hold the lock across load+append+save so two concurrent notes on
+        # the same ticket can't both load the pre-append note list and
+        # then race each other's saves, dropping one of the notes.
+        target: dict | None = None
+        actor = (actor_email or "unknown").lower()
+        with self.storage.atomic():
+            tickets = self._load()
+            for ticket in tickets:
+                if ticket.get("id") != ticket_id:
+                    continue
+                ticket.setdefault("notes", []).append({
+                    "at": _now_iso(),
+                    "by": actor,
+                    "text": text,
+                })
+                ticket["updated_at"] = _now_iso()
+                self._save(tickets)
+                target = ticket
+                break
+        if target is None:
+            return None
 
-            submitter = (ticket.get("submitted_by") or "").lower()
-            if actor != submitter:
-                # Note from someone other than the submitter (typically admin);
-                # send a heads-up email if the submitter opted in.
-                self._maybe_email_submitter(
-                    ticket,
-                    subject=f"New note on your repair ticket: {ticket.get('title', '')}",
-                    body=(
-                        f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
-                        f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
-                        f"{text}\n\n"
-                        f"Reply from the ticket page in the Somewheria portal."
+        ticket = target
+        submitter = (ticket.get("submitted_by") or "").lower()
+        if actor != submitter:
+            # Note from someone other than the submitter (typically admin);
+            # send a heads-up email if the submitter opted in.
+            self._maybe_email_submitter(
+                ticket,
+                subject=f"New note on your repair ticket: {ticket.get('title', '')}",
+                body=(
+                    f"Hi {ticket.get('submitter_name') or 'there'},\n\n"
+                    f"{actor} added a note to your repair ticket (reference {ticket_id[:8]}):\n\n"
+                    f"{text}\n\n"
+                    f"Reply from the ticket page in the Somewheria portal."
+                ),
+            )
+        else:
+            # Note from the submitter — notify the internal inbox so staff
+            # see a renter reply even if they're not watching the dashboard.
+            try:
+                self.notifications.send_email(
+                    f"Renter note on ticket: {ticket.get('title', '')}",
+                    (
+                        f"Ticket: {ticket_id[:8]}\n"
+                        f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
+                        f"{text}"
                     ),
                 )
-            else:
-                # Note from the submitter — notify the internal inbox so staff
-                # see a renter reply even if they're not watching the dashboard.
-                try:
-                    self.notifications.send_email(
-                        f"Renter note on ticket: {ticket.get('title', '')}",
-                        (
-                            f"Ticket: {ticket_id[:8]}\n"
-                            f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
-                            f"{text}"
-                        ),
-                    )
-                except Exception as exc:
-                    self.logger.warning("Failed to forward renter note: %s", exc)
+            except Exception as exc:
+                self.logger.warning("Failed to forward renter note: %s", exc)
 
-            try:
-                self.notifications.log_site_change(
-                    actor,
-                    "ticket_note_added",
-                    {"ticket_id": ticket_id},
-                )
-            except Exception:
-                pass
-            return ticket
-        return None
+        try:
+            self.notifications.log_site_change(
+                actor,
+                "ticket_note_added",
+                {"ticket_id": ticket_id},
+            )
+        except Exception:
+            pass
+        return ticket

--- a/test_services.py
+++ b/test_services.py
@@ -257,6 +257,58 @@ class FileStorageServiceTestCase(unittest.TestCase):
 
         save_json_mock.assert_called_once_with(self.config.contracts_file, contracts)
 
+    def test_concurrent_add_pending_registration_preserves_all_writes(self):
+        """Lost-update race fix: load+save runs under the file lock.
+
+        Without holding ``file_lock`` across get_pending_registrations() and
+        save_json_file(), N concurrent submissions all load the pre-write
+        list, then race each other's writes — empirically ~80% of entries
+        get silently dropped (one run with N=50 kept only 8 on disk). The
+        in-process Flask dev server threads each request, so this race is
+        reachable on the live site, not a theoretical concern.
+        """
+        import threading
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        config = SimpleNamespace(
+            registration_file=Path(tmpdir.name) / "registrations.json",
+            user_roles_file=Path(tmpdir.name) / "roles.json",
+            renter_profile_file=Path(tmpdir.name) / "profiles.json",
+            contracts_file=Path(tmpdir.name) / "contracts.json",
+            lead_capture_file=Path(tmpdir.name) / "lead_captures.json",
+        )
+        service = FileStorageService(config)
+
+        N = 32
+        barrier = threading.Barrier(N)
+        successes: list[bool] = []
+        successes_lock = threading.Lock()
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            ok = service.add_pending_registration({
+                "email": f"user{i}@example.com",
+                "name": f"User {i}",
+                "reason": "race",
+            })
+            with successes_lock:
+                successes.append(ok)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stored = service.get_pending_registrations()
+        self.assertEqual(sum(successes), N)
+        self.assertEqual(len(stored), N)
+        stored_emails = {item.get("email") for item in stored}
+        self.assertEqual(
+            stored_emails,
+            {f"user{i}@example.com" for i in range(N)},
+        )
+
 
 class AppointmentServiceTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

`FileStorageService` was using a plain `Lock` that protected only the inner load and the inner save — not the full read-modify-write sequence. Two threads doing concurrent submissions both loaded the pre-write list, both modified it, and both saved, silently dropping one update. The Flask dev server threads each request, so this race is reachable on the live site (not just a theoretical concern).

Reproduced on `origin/main` before the fix: 50 concurrent `add_pending_registration` calls returned `True` for all 50, but only **8** entries ended up on disk — 42 registrations silently lost. After the fix, all 50 persist.

The same load-modify-save pattern exists in `TicketService` (`create_ticket`, `update_ticket`, `set_email_updates`, JIRA key persist, `add_photo`, `add_note`) and would similarly drop tickets/notes/photo-metadata on concurrent writes.

### Changes
- Switch `FileStorageService.file_lock` from `Lock` to `RLock` and expose an `atomic()` context manager.
- Add a no-op `atomic()` to `SqlStorageService` for API symmetry (its writes already use real transactions).
- Wrap the read-modify-write methods in `FileStorageService` (`add_pending_registration`, `remove_pending_registration`, `set_user_role`, `delete_user_role`, `add_pending_lead_capture`, `remove_pending_lead_capture`) with `with self.file_lock:`.
- Wrap the load+modify+save sequences in `TicketService` with `with self.storage.atomic():`. Notification side effects (SMTP, change log) stay outside the lock so a slow send can't stall other ticket ops.
- Add a regression test that drives 32 concurrent registrations and asserts all 32 persist.

## Test plan

- [x] Full unit test suite passes (`python -m unittest discover` → 739 tests OK).
- [x] `ruff check .` passes.
- [x] Race repro pre-fix: 50 attempted, 8 stored. Post-fix: 50/50 stored.
- [x] Same repro for `TicketService.create_ticket`: 50/50 stored after fix.
- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Us8b7nWCrzoVSjdRDgqQrh)_