### PR TITLE
Fix lost-update race in admin contracts and renter profile routes

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -187,10 +187,15 @@ def _backfill_contract_ids(services, contracts_for_email: list[dict], email: str
         # canonical free-form ``status`` field admins set in the form.
         contract["status_class"] = _classify_contract_status(contract)
     if needs_save:
+        # Hold the storage lock across load+modify+save so a concurrent
+        # admin add/delete on the same renter can't race the backfill and
+        # silently lose one side's write. Mirrors the lost-update fix in
+        # commit e062313 for tickets and pending registrations.
         try:
-            all_contracts = services.storage.get_renter_contracts()
-            all_contracts[email] = contracts_for_email
-            services.storage.save_renter_contracts(all_contracts)
+            with services.storage.atomic():
+                all_contracts = services.storage.get_renter_contracts()
+                all_contracts[email] = contracts_for_email
+                services.storage.save_renter_contracts(all_contracts)
         except Exception:
             pass
     return contracts_for_email
@@ -591,28 +596,40 @@ def renter_profile():
     services = get_services()
     user = get_current_user()
     email = user["email"].lower()
-    profiles = services.storage.get_renter_profiles()
-    profile = profiles.get(
-        email,
-        {
+    success = None
+    if request.method == "POST":
+        # Hold the storage lock across load+modify+save so two renters
+        # editing their profiles concurrently can't race each other's
+        # saves (the read-modify-write reads ALL profiles into memory and
+        # writes them all back, so the second save would otherwise clobber
+        # the first). Mirrors the lost-update fix in commit e062313 for
+        # tickets and pending registrations.
+        with services.storage.atomic():
+            profiles = services.storage.get_renter_profiles()
+            profile = profiles.get(email) or {
+                "name": user.get("name", ""),
+                "contact": "",
+                "email_status_updates": True,
+                "rcs_status_updates": True,
+            }
+            profile["name"] = request.form.get("name", "").strip()[:120]
+            profile["contact"] = request.form.get("contact", "").strip()[:200]
+            profile["email_status_updates"] = bool(request.form.get("email_status_updates"))
+            profile["rcs_status_updates"] = bool(request.form.get("rcs_status_updates"))
+            profiles[email] = profile
+            services.storage.save_renter_profiles(profiles)
+        success = "Profile updated."
+    else:
+        profiles = services.storage.get_renter_profiles()
+        profile = profiles.get(email) or {
             "name": user.get("name", ""),
             "contact": "",
             "email_status_updates": True,
             "rcs_status_updates": True,
-        },
-    )
-    # Backfill fields for profiles created before the preference existed.
-    profile.setdefault("email_status_updates", True)
-    profile.setdefault("rcs_status_updates", True)
-    success = None
-    if request.method == "POST":
-        profile["name"] = request.form.get("name", "").strip()[:120]
-        profile["contact"] = request.form.get("contact", "").strip()[:200]
-        profile["email_status_updates"] = bool(request.form.get("email_status_updates"))
-        profile["rcs_status_updates"] = bool(request.form.get("rcs_status_updates"))
-        profiles[email] = profile
-        services.storage.save_renter_profiles(profiles)
-        success = "Profile updated."
+        }
+        # Backfill fields for profiles created before the preference existed.
+        profile.setdefault("email_status_updates", True)
+        profile.setdefault("rcs_status_updates", True)
     return render_template("renter_profile.html", profile=profile, user=user, success=success, title="Edit Profile")
 
 
@@ -691,18 +708,25 @@ def admin_contracts():
                             pdf_filename = ""
                             error = "Failed to save PDF; contract not added."
                 if error is None:
-                    contracts_data.setdefault(renter_email, []).append(
-                        {
-                            "id": contract_id,
-                            "property_name": property_name,
-                            "start_date": start_date,
-                            "end_date": end_date,
-                            "status": status,
-                            "pdf_filename": pdf_filename,
-                            "created_at": utcnow_iso(),
-                        }
-                    )
-                    services.storage.save_renter_contracts(contracts_data)
+                    new_contract = {
+                        "id": contract_id,
+                        "property_name": property_name,
+                        "start_date": start_date,
+                        "end_date": end_date,
+                        "status": status,
+                        "pdf_filename": pdf_filename,
+                        "created_at": utcnow_iso(),
+                    }
+                    # Hold the storage lock across load+modify+save so two
+                    # admins adding contracts concurrently can't both read
+                    # the pre-add snapshot and then race each other's saves
+                    # (which silently drops one of the new contracts on the
+                    # file backend). Same class of fix as commit e062313
+                    # made for tickets and pending registrations.
+                    with services.storage.atomic():
+                        contracts_data = services.storage.get_renter_contracts()
+                        contracts_data.setdefault(renter_email, []).append(new_contract)
+                        services.storage.save_renter_contracts(contracts_data)
                     success = f"Contract added for {renter_email}."
         elif action == "delete":
             renter_email = request.form.get("renter_email", "").strip().lower()
@@ -710,26 +734,34 @@ def admin_contracts():
             if renter_email and contract_index is not None:
                 try:
                     contract_idx = int(contract_index)
-                    if renter_email in contracts_data and 0 <= contract_idx < len(contracts_data[renter_email]):
-                        removed = contracts_data[renter_email][contract_idx]
-                        # Best-effort delete of the on-disk PDF. Validate the
-                        # filename the same way the download path does so a
-                        # tampered ``pdf_filename`` can't unlink an arbitrary
-                        # file outside the upload directory.
-                        pdf_filename = removed.get("pdf_filename") or ""
-                        safe_pdf_path = _safe_contract_pdf_path(services, pdf_filename)
-                        if safe_pdf_path is not None:
-                            try:
-                                services.storage.delete_file(safe_pdf_path)
-                            except Exception:
-                                pass
-                        del contracts_data[renter_email][contract_idx]
-                        if not contracts_data[renter_email]:
-                            del contracts_data[renter_email]
-                        services.storage.save_renter_contracts(contracts_data)
-                        success = f"Contract removed for {renter_email}."
-                    else:
-                        error = "Contract not found."
+                    # Hold the storage lock across load+modify+save so a
+                    # delete racing another admin's add (or delete) on the
+                    # same renter can't drop one side's write. The PDF
+                    # unlink and the JSON save run together so the file and
+                    # the metadata stay in sync.
+                    with services.storage.atomic():
+                        contracts_data = services.storage.get_renter_contracts()
+                        if renter_email in contracts_data and 0 <= contract_idx < len(contracts_data[renter_email]):
+                            removed = contracts_data[renter_email][contract_idx]
+                            # Best-effort delete of the on-disk PDF. Validate
+                            # the filename the same way the download path
+                            # does so a tampered ``pdf_filename`` can't
+                            # unlink an arbitrary file outside the upload
+                            # directory.
+                            pdf_filename = removed.get("pdf_filename") or ""
+                            safe_pdf_path = _safe_contract_pdf_path(services, pdf_filename)
+                            if safe_pdf_path is not None:
+                                try:
+                                    services.storage.delete_file(safe_pdf_path)
+                                except Exception:
+                                    pass
+                            del contracts_data[renter_email][contract_idx]
+                            if not contracts_data[renter_email]:
+                                del contracts_data[renter_email]
+                            services.storage.save_renter_contracts(contracts_data)
+                            success = f"Contract removed for {renter_email}."
+                        else:
+                            error = "Contract not found."
                 except ValueError:
                     error = "Invalid contract index."
             else:

--- a/somewheria_app/services/sql_storage.py
+++ b/somewheria_app/services/sql_storage.py
@@ -18,6 +18,7 @@ import contextlib
 import json
 import os
 import tempfile
+import threading
 from pathlib import Path
 
 from .console import get_console_logger
@@ -29,18 +30,31 @@ class SqlStorageService:
         self.config = config
         self.logger = get_console_logger("storage-sql")
         self.db = Database(config.sqlite_file)
+        # Re-entrant lock backing :meth:`atomic`. Individual writes already
+        # go through ``db.transaction()``, but a route-level
+        # read-modify-write sequence spans multiple transactions — two
+        # concurrent admins both load the pre-write snapshot and race each
+        # other's saves, silently dropping one of the updates. Holding this
+        # lock around the route block (via ``with storage.atomic():``)
+        # serializes those sequences in this process, mirroring the
+        # guarantee :class:`FileStorageService` gets from ``file_lock``.
+        # Per-process is sufficient for the single-worker deployment model
+        # documented in ``services/storage.py``.
+        self._atomic_lock = threading.RLock()
 
     @contextlib.contextmanager
     def atomic(self):
-        """No-op context manager mirroring FileStorageService.atomic().
+        """Serialize a multi-step read-modify-write across writers.
 
-        SQL writes already go through ``db.transaction()`` so a load+save
-        wrapper isn't required for correctness. Callers (TicketService et
-        al.) use ``with storage.atomic():`` without branching on backend;
-        that boils down to a real RLock under the file backend and to this
-        pass-through here.
+        SQL writes already go through ``db.transaction()``, but a load+save
+        sequence in a route handler still races concurrent callers because
+        each call opens its own transaction. Holding ``self._atomic_lock``
+        across the block makes the whole sequence a single critical
+        section, exactly like ``FileStorageService.atomic()`` does on the
+        file backend.
         """
-        yield
+        with self._atomic_lock:
+            yield
 
     # ---------------------------------------------------------------- helpers
 

--- a/test_services.py
+++ b/test_services.py
@@ -309,6 +309,100 @@ class FileStorageServiceTestCase(unittest.TestCase):
             {f"user{i}@example.com" for i in range(N)},
         )
 
+    def test_atomic_serializes_concurrent_renter_contracts_updates(self):
+        """Route-level read-modify-write under ``atomic()`` preserves all writes.
+
+        ``admin_contracts`` (add/delete) and ``_backfill_contract_ids`` each
+        do ``get_renter_contracts() -> mutate -> save_renter_contracts()``
+        without holding the storage lock, so two concurrent admins racing
+        on the contracts file silently dropped one side's update — same
+        lost-update class commit e062313 fixed for tickets and pending
+        registrations. The route handlers now wrap that sequence in
+        ``with services.storage.atomic():``; this regression test verifies
+        the lock is actually held end-to-end on the file backend.
+        """
+        import threading
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        config = SimpleNamespace(
+            registration_file=Path(tmpdir.name) / "registrations.json",
+            user_roles_file=Path(tmpdir.name) / "roles.json",
+            renter_profile_file=Path(tmpdir.name) / "profiles.json",
+            contracts_file=Path(tmpdir.name) / "contracts.json",
+            lead_capture_file=Path(tmpdir.name) / "lead_captures.json",
+        )
+        service = FileStorageService(config)
+
+        N = 32
+        barrier = threading.Barrier(N)
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            # Mirror what admin_contracts add now does after the fix.
+            with service.atomic():
+                contracts = service.get_renter_contracts()
+                contracts.setdefault(f"renter{i}@example.com", []).append(
+                    {"id": f"c{i}", "property_name": f"P{i}"}
+                )
+                service.save_renter_contracts(contracts)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stored = service.get_renter_contracts()
+        self.assertEqual(len(stored), N)
+        self.assertEqual(
+            {email for email in stored},
+            {f"renter{i}@example.com" for i in range(N)},
+        )
+
+    def test_atomic_serializes_concurrent_renter_profile_updates(self):
+        """``renter_profile`` POST now wraps load+modify+save in ``atomic()``.
+
+        Without the wrap, two renters POSTing to /renter/profile at the
+        same time both load the global profiles dict, each modifies their
+        own row, and the second save clobbers the first — even though
+        they're editing different rows — because the file IS the dict.
+        """
+        import threading
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        config = SimpleNamespace(
+            registration_file=Path(tmpdir.name) / "registrations.json",
+            user_roles_file=Path(tmpdir.name) / "roles.json",
+            renter_profile_file=Path(tmpdir.name) / "profiles.json",
+            contracts_file=Path(tmpdir.name) / "contracts.json",
+            lead_capture_file=Path(tmpdir.name) / "lead_captures.json",
+        )
+        service = FileStorageService(config)
+
+        N = 32
+        barrier = threading.Barrier(N)
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            # Mirror what renter_profile POST now does after the fix.
+            with service.atomic():
+                profiles = service.get_renter_profiles()
+                profiles[f"renter{i}@example.com"] = {"name": f"Renter {i}"}
+                service.save_renter_profiles(profiles)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stored = service.get_renter_profiles()
+        self.assertEqual(len(stored), N)
+        self.assertEqual(
+            set(stored),
+            {f"renter{i}@example.com" for i in range(N)},
+        )
+
 
 class AppointmentServiceTestCase(unittest.TestCase):
     def setUp(self):

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -237,5 +237,56 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
 
 
+class AtomicTestCase(SqlStorageBaseTestCase):
+    """``atomic()`` must serialize route-level read-modify-write sequences.
+
+    Individual SQL writes already run inside ``db.transaction()``, but a
+    load+save in a route handler spans two transactions and races
+    concurrent writers — exactly the lost-update class commit e062313
+    fixed for the JSON backend. The SQL backend's ``atomic()`` used to
+    be a no-op; it now acquires a process-wide RLock so the same
+    ``with storage.atomic():`` wrap fixes both backends.
+    """
+
+    def test_atomic_serializes_renter_contracts_updates(self):
+        import threading
+
+        N = 16
+        barrier = threading.Barrier(N)
+
+        def worker(i: int) -> None:
+            barrier.wait()
+            with self.storage.atomic():
+                contracts = self.storage.get_renter_contracts()
+                contracts.setdefault(f"renter{i}@example.com", []).append(
+                    {"id": f"c{i}", "property_name": f"P{i}"}
+                )
+                self.storage.save_renter_contracts(contracts)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stored = self.storage.get_renter_contracts()
+        self.assertEqual(len(stored), N)
+        self.assertEqual(
+            set(stored),
+            {f"renter{i}@example.com" for i in range(N)},
+        )
+
+    def test_atomic_is_reentrant(self):
+        # FileStorageService.atomic() is re-entrant because file_lock is an
+        # RLock; the SQL backend must match so a nested ``with atomic():``
+        # block (e.g. a helper that itself calls atomic()) doesn't deadlock.
+        with self.storage.atomic():
+            with self.storage.atomic():
+                self.storage.set_user_role("nested@example.com", "renter")
+        self.assertEqual(
+            self.storage.get_user_roles(), {"nested@example.com": "renter"}
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Same lost-update class commit e062313 fixed for tickets and pending registrations, but missed for the route-level operations on `renter_contracts` and `renter_profiles`:

- `admin_contracts` (add/delete) does `get_renter_contracts() → mutate → save_renter_contracts()` without holding the storage lock. Two concurrent admins both read the pre-write snapshot, mutate, then race their saves — the second save silently drops the first's contract.
- `renter_profile` POST has the same pattern over the global profiles dict. Two renters editing concurrently can clobber each other even though they're editing different rows, because the file IS the dict.
- `_backfill_contract_ids` has the same shape on legacy data.

Reproduced locally: 32 concurrent `add_contract` calls under the old code preserved 18 contracts on disk; with the `atomic()` wrap, all 32.

## Changes

- Wrap the racy sequences in `with services.storage.atomic():` so load+modify+save runs under `file_lock` end-to-end.
- Promote `SqlStorageService.atomic()` from a no-op to a real RLock so the same wrap fixes both backends. Individual SQL writes are already transactional, but a load+save in a route handler still spans two transactions and races concurrent writers the same way.
- Two regression tests in `test_services.py` mirror the route-level pattern with `FileStorageService`; an atomic concurrency test and a re-entrancy test in `test_sql_storage.py` pin the SQL backend behavior.

## Test plan

- [x] Full unittest suite: 743 tests OK (up from 739)
- [x] Ruff clean
- [x] Demonstrated the race exists without `atomic()` (18/32 contracts preserved) and is fixed with it (32/32)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGov852Cfv5pw1Z8RJam8c)_