### PR TITLE
Validate email format on admin user-add and contract-add routes

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -414,7 +414,14 @@ def admin_dashboard_combined():
         elif action == "add":
             new_role = request.form.get("role", "renter").strip()
             user_roles = services.storage.get_user_roles()
-            if email in user_roles and user_roles.get(email) != "revoked":
+            # Reject malformed emails at the admin boundary too. The public
+            # /register path already validates with is_valid_email; without
+            # the same gate here, an admin paste-error puts a garbage entry
+            # like "foo" into user_roles.json that can never match a real
+            # OAuth login and just pollutes the table.
+            if not is_valid_email(email):
+                error = "A valid email is required."
+            elif email in user_roles and user_roles.get(email) != "revoked":
                 error = "User already exists."
             elif new_role not in ALLOWED_ROLES:
                 error = "Invalid role."
@@ -580,7 +587,12 @@ def admin_users():
             else:
                 error = "User not found."
         elif new_role in ALLOWED_ROLES:
-            if not _can_act_on(actor_role, target_role) or not _can_act_on(actor_role, new_role):
+            # Defense in depth: reject malformed emails before they touch
+            # user_roles storage. Delete is intentionally exempt so an admin
+            # can still clean up legacy entries that predate this check.
+            if not is_valid_email(email):
+                error = "A valid email is required."
+            elif not _can_act_on(actor_role, target_role) or not _can_act_on(actor_role, new_role):
                 error = "You cannot assign a role at or above your own."
             else:
                 services.storage.set_user_role(email, new_role)
@@ -688,6 +700,12 @@ def admin_contracts():
             status = request.form.get("status", "Active").strip()[:32]
             if not all([renter_email, property_name, start_date, end_date]):
                 error = "All fields are required."
+            elif not is_valid_email(renter_email):
+                # Reject malformed renter emails before they touch
+                # renter_contracts storage. A typo like "renter@" otherwise
+                # creates an orphan contract that no real OAuth login can
+                # ever surface for the renter.
+                error = "A valid renter email is required."
             else:
                 contract_id = uuid_lib.uuid4().hex
                 pdf_filename = ""

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -588,6 +588,26 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"updated to renter", response.data)
         set_user_role_mock.assert_called_once_with("user@example.com", "renter")
 
+    def test_admin_users_rejects_malformed_email_on_role_assignment(self):
+        # Defense-in-depth check: an admin pasting a typo'd value like "not-an-email"
+        # should be rejected at the route boundary before user_roles storage is
+        # touched. Without this gate, garbage entries accumulate in user_roles.json
+        # that no real OAuth login can ever match.
+        self.login_as("admin")
+        with patch.object(self.services.storage, "set_user_role") as set_user_role_mock, patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ):
+            response = self.client.post(
+                "/admin/users",
+                data={"email": "not-an-email", "role": "renter", "action": "update"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"valid email is required", response.data)
+        set_user_role_mock.assert_not_called()
+
     def test_admin_dashboard_forbids_standard_admin(self):
         self.login_as("admin")
 
@@ -627,6 +647,25 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"added as admin", response.data)
         set_user_role_mock.assert_called_once_with("new@example.com", "admin")
         log_site_change_mock.assert_called_once()
+
+    def test_admin_dashboard_rejects_malformed_email_on_add(self):
+        # Mirror of test_admin_users_rejects_malformed_email_on_role_assignment for
+        # the combined admin dashboard's "add user" path. A typo'd email must not
+        # reach user_roles storage.
+        self.login_as("high_admin", email="owner@example.com")
+        with patch.object(self.services.analytics, "dashboard_data", return_value=({"visits": 10}, {"labels": []})), patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ), patch.object(self.services.storage, "set_user_role") as set_user_role_mock:
+            response = self.client.post(
+                "/admin/dashboard",
+                data={"action": "add", "email": "not-an-email", "role": "admin"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"valid email is required", response.data)
+        set_user_role_mock.assert_not_called()
 
     def test_renter_dashboard_loads_for_renter(self):
         self.login_as("renter", email="renter@example.com")
@@ -711,6 +750,30 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"All fields are required.", response.data)
+
+    def test_admin_contracts_add_rejects_malformed_renter_email(self):
+        # A typo like "renter@" must not be persisted: it would create an
+        # orphan contract that no real OAuth login can ever surface.
+        self.login_as("admin")
+        with patch.object(self.services.storage, "get_renter_contracts", return_value={}), patch.object(
+            self.services.storage,
+            "save_renter_contracts",
+        ) as save_contracts_mock:
+            response = self.client.post(
+                "/admin/contracts",
+                data={
+                    "action": "add",
+                    "renter_email": "renter@",
+                    "property_name": "Maple House",
+                    "start_date": "2030-01-01",
+                    "end_date": "2030-12-31",
+                    "status": "Active",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"valid renter email is required", response.data)
+        save_contracts_mock.assert_not_called()
 
     def test_admin_contracts_add_successfully_saves(self):
         self.login_as("admin")


### PR DESCRIPTION
## Summary

Public-facing `/register` and `/lead-captures` already gate on `is_valid_email`, but the admin user-management and contract-management routes did not. A paste error like `"foo"` or `"renter@"` would persist into `user_roles.json` / `renter_contracts.json` — entries that no real OAuth login can ever match, polluting the table and the admin UI.

This change adds the same `is_valid_email` check at three admin write paths:

- `admin_users` role assignment (the catch-all "add or update" branch)
- `admin_dashboard_combined` "add" action
- `admin_contracts` "add" action (validates `renter_email`)

Delete remains exempt so admins can still clean up legacy garbage entries that predate this check.

## Test plan

- [x] Three new tests in `test_routes_expanded.py` cover each of the three rejected paths and assert that `set_user_role` / `save_renter_contracts` are not called when the email is malformed.
- [x] Full suite: `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 746 tests pass (was 743 before, +3 new).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AiQn2qK7LRjDEaap1y8DHh)_