### PR TITLE
Coerce null upstream scalars (name, address, rent, etc.) to defaults

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -376,12 +376,25 @@ class PropertyService:
         # out of the listing entirely.
         if not isinstance(normalized["included_amenities"], list):
             normalized["included_amenities"] = []
-        normalized.setdefault("bedrooms", "N/A")
-        normalized.setdefault("bathrooms", "N/A")
-        normalized.setdefault("rent", "N/A")
-        normalized.setdefault("sqft", "N/A")
-        normalized.setdefault("deposit", "N/A")
-        normalized.setdefault("address", "N/A")
+        # Replace any missing OR explicit-null scalar with the safe default.
+        # ``setdefault`` alone leaves ``None`` in place, so a partially-filled
+        # upstream listing (``{"name": null, "address": null, ...}``) would
+        # render as the literal string "None" in templates and page titles.
+        # Same class of bug as the description / included_amenities null fixes
+        # above — here it doesn't crash, it just produces ugly UI.
+        _scalar_defaults = (
+            ("name", "Property"),
+            ("address", "N/A"),
+            ("rent", "N/A"),
+            ("deposit", "N/A"),
+            ("sqft", "N/A"),
+            ("bedrooms", "N/A"),
+            ("bathrooms", "N/A"),
+            ("lease_length", "12 months"),
+        )
+        for key, default in _scalar_defaults:
+            if normalized.get(key) is None:
+                normalized[key] = default
         # Coerce a null / non-string description to "". Upstream occasionally
         # returns ``"description": null`` for partially-filled listings; without
         # this the ``.lower()`` call below raises AttributeError, fetch_property_record
@@ -391,9 +404,12 @@ class PropertyService:
         if not isinstance(description, str):
             description = ""
         normalized["description"] = description
-        normalized.setdefault("blurb", description)
-        normalized.setdefault("lease_length", "12 months")
-        normalized.setdefault("name", "Property")
+        # blurb mirrors description as its fallback; coerce a null/non-string
+        # blurb the same way so templates never render the literal "None".
+        blurb = normalized.get("blurb", description)
+        if not isinstance(blurb, str):
+            blurb = description
+        normalized["blurb"] = blurb
         normalized.setdefault("photos", [])
         if not isinstance(normalized["photos"], list):
             normalized["photos"] = []
@@ -447,7 +463,11 @@ class PropertyService:
         else:
             ada_accessible = "Unknown"
         normalized["ada_accessible"] = ada_accessible
-        normalized.setdefault("thumbnail", normalized["photos"][0] if normalized["photos"] else "")
+        # ``thumbnail`` may legitimately be missing OR null. Treat both as
+        # "use the first photo if we have one, otherwise empty" so the
+        # template's <img src="{{ property.thumbnail }}"> never gets None.
+        if not normalized.get("thumbnail"):
+            normalized["thumbnail"] = normalized["photos"][0] if normalized["photos"] else ""
         normalized["tour_url"] = sanitize_tour_url(normalized.get("tour_url", ""))
         return normalized
 

--- a/test_services.py
+++ b/test_services.py
@@ -590,6 +590,61 @@ class PropertyServiceTestCase(unittest.TestCase):
 
         self.assertEqual(normalized["included_amenities"], [])
 
+    def test_normalize_property_coerces_null_scalars_to_defaults(self):
+        # Same upstream-shape bug as the description / included_amenities
+        # null fixes: a partially-filled listing can return ``{"name": null,
+        # "address": null, "rent": null, ...}``. ``setdefault`` leaves None
+        # in place, so templates / page titles render the literal "None".
+        # The coercion path here must replace each scalar with its safe
+        # default so the listing is presentable rather than ugly.
+        normalized = self.service.normalize_property(
+            {
+                "name": None,
+                "address": None,
+                "rent": None,
+                "deposit": None,
+                "sqft": None,
+                "bedrooms": None,
+                "bathrooms": None,
+                "lease_length": None,
+                "thumbnail": None,
+            },
+            "prop-1",
+        )
+
+        self.assertEqual(normalized["name"], "Property")
+        self.assertEqual(normalized["address"], "N/A")
+        self.assertEqual(normalized["rent"], "N/A")
+        self.assertEqual(normalized["deposit"], "N/A")
+        self.assertEqual(normalized["sqft"], "N/A")
+        self.assertEqual(normalized["bedrooms"], "N/A")
+        self.assertEqual(normalized["bathrooms"], "N/A")
+        self.assertEqual(normalized["lease_length"], "12 months")
+        # Thumbnail falls back to the first photo, or "" when no photos exist.
+        self.assertEqual(normalized["thumbnail"], "")
+
+    def test_normalize_property_null_thumbnail_falls_back_to_first_photo(self):
+        # If the upstream payload explicitly nulls ``thumbnail`` but does
+        # ship a photo list, prefer the first photo over leaving None on the
+        # record (which would render as <img src="None">).
+        normalized = self.service.normalize_property(
+            {"name": "Maple", "thumbnail": None, "photos": ["photo-1.jpg"]},
+            "prop-1",
+        )
+
+        self.assertEqual(normalized["thumbnail"], "photo-1.jpg")
+
+    def test_normalize_property_coerces_null_blurb_to_description(self):
+        # blurb mirrors description on the listing card; a null upstream
+        # value previously slipped through to the template and rendered as
+        # the string "None".
+        normalized = self.service.normalize_property(
+            {"name": "Maple", "description": "Cozy duplex.", "blurb": None},
+            "prop-1",
+        )
+
+        self.assertEqual(normalized["blurb"], "Cozy duplex.")
+
     def test_property_payload_from_form_merges_custom_amenities(self):
         form = DummyForm(
             values={


### PR DESCRIPTION
## Summary

`PropertyService.normalize_property` uses `setdefault` to fill in placeholder values when an upstream key is absent, but `setdefault` leaves an explicit `None` in place. A partially-filled upstream listing (`{"name": null, "address": null, "rent": null, ...}`) slipped past normalization and rendered as the literal string "None" in templates, page titles, and the listing card thumbnail (``'&lt;img src="None"&gt;'``).

This is the same class of bug as the existing null-coercion fixes for `description` (7f7448b), `included_amenities` (06c803f, 4029d0c), and the `photos` list — there those nulls actually crashed the property and dropped it from the listing; here it doesn't crash, it just produces ugly UI.

### Changes

- `somewheria_app/services/properties.py`: replace per-field `setdefault` for `name`/`address`/`rent`/`deposit`/`sqft`/`bedrooms`/`bathrooms`/`lease_length` with a loop that also handles explicit `None`. Add the same coercion for `blurb` and `thumbnail`.
- `test_services.py`: three new tests covering null scalars (replaced with defaults), null thumbnail (falls back to first photo), and null blurb (falls back to description).

### Test plan

- [x] `python -m unittest discover` — 746 tests pass (3 new)
- [x] `ruff check .` — clean
- [x] Manual verification: `normalize_property({'name': None, 'address': None, 'rent': None})` now returns `{'name': 'Property', 'address': 'N/A', 'rent': 'N/A', ...}` instead of `None`s

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAEGX4zRtxewizzbqBUE8R)_