### PR TITLE
Harden create_property JSON handling and surface image-association HTTP errors

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -554,7 +554,17 @@ class PropertyService:
         payload = self.property_payload_from_form(form)
         response = requests.post(f"{self.config.api_base_url}/properties", json=payload, timeout=20)
         response.raise_for_status()
-        new_id = response.json().get("id") or response.json().get("property_id") or ""
+        # Parse once and tolerate a non-dict / invalid-JSON body rather than
+        # crashing the admin POST with AttributeError or JSONDecodeError.
+        # The upstream creates the property either way; a missing id just
+        # means the change-log entry won't carry it.
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        if not isinstance(body, dict):
+            body = {}
+        new_id = body.get("id") or body.get("property_id") or ""
         self.notifications.log_site_change(
             actor_email,
             "property_created",
@@ -724,11 +734,19 @@ class PropertyService:
         # forward the stable relative URL to the upstream API.
         absolute_url = relative_url
         try:
-            requests.post(
+            assoc_response = requests.post(
                 f"{self.config.api_base_url}/properties/{property_id}/photos",
                 json={"image_url": absolute_url},
                 timeout=20,
             )
+            # Without raise_for_status() a 4xx/5xx response is silently
+            # swallowed: the local file is saved and the change-log records
+            # a successful "image_added", but the upstream never associates
+            # the URL, so the next cache refresh blanks it from the listing
+            # and the local file becomes orphaned in static/uploads. Treat
+            # the HTTP error the same way as a connection failure and at
+            # least surface a warning so the operator can investigate.
+            assoc_response.raise_for_status()
         except Exception as exc:
             self.logger.warning("Failed to associate uploaded image with property %s: %s", property_id, exc)
         self.trigger_background_refresh(actor_email)

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
+import requests
 from flask import Flask, Response, abort
 from PIL import Image
 
@@ -39,7 +40,7 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.service = PropertyService(self.config, self.notifications)
 
     def tearDown(self):
-        for filename in ("prop-1_abc123.png", "prop-1_bad.png", "prop-1_assoc.png"):
+        for filename in ("prop-1_abc123.png", "prop-1_bad.png", "prop-1_assoc.png", "prop-1_httperr.png"):
             file_path = self.upload_dir / filename
             if file_path.exists():
                 file_path.unlink()
@@ -482,6 +483,61 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.notifications.log_site_change.assert_called_once()
         trigger_mock.assert_called_once_with("admin@example.com")
 
+    def test_create_property_returns_empty_id_when_response_is_not_a_dict(self):
+        # Upstream sometimes returns a JSON list, scalar, or null body; the old
+        # ``response.json().get(...)`` chain would raise AttributeError and 500
+        # the admin POST. The route should still succeed with an empty new_id.
+        form = SimpleNamespace(
+            get=lambda key, default="": default,
+            getlist=lambda key: [],
+        )
+        response = Mock()
+        response.json.return_value = []  # list, not dict
+
+        with patch.object(self.service, "property_payload_from_form", return_value={"address": "123 Main"}), patch(
+            "somewheria_app.services.properties.requests.post",
+            return_value=response,
+        ), patch.object(self.service, "trigger_background_refresh"):
+            new_id = self.service.create_property(form, "admin@example.com")
+
+        self.assertEqual(new_id, "")
+        self.notifications.log_site_change.assert_called_once()
+
+    def test_create_property_returns_empty_id_when_response_body_is_invalid_json(self):
+        form = SimpleNamespace(
+            get=lambda key, default="": default,
+            getlist=lambda key: [],
+        )
+        response = Mock()
+        response.json.side_effect = ValueError("no json body")
+
+        with patch.object(self.service, "property_payload_from_form", return_value={"address": "123 Main"}), patch(
+            "somewheria_app.services.properties.requests.post",
+            return_value=response,
+        ), patch.object(self.service, "trigger_background_refresh"):
+            new_id = self.service.create_property(form, "admin@example.com")
+
+        self.assertEqual(new_id, "")
+
+    def test_create_property_parses_response_json_only_once(self):
+        # Guard against regressing into the double-parse pattern that wasted
+        # CPU and made the code fragile to non-cached response shapes.
+        form = SimpleNamespace(
+            get=lambda key, default="": default,
+            getlist=lambda key: [],
+        )
+        response = Mock()
+        response.json.return_value = {"id": "prop-99"}
+
+        with patch.object(self.service, "property_payload_from_form", return_value={"address": "123 Main"}), patch(
+            "somewheria_app.services.properties.requests.post",
+            return_value=response,
+        ), patch.object(self.service, "trigger_background_refresh"):
+            new_id = self.service.create_property(form, "admin@example.com")
+
+        self.assertEqual(new_id, "prop-99")
+        self.assertEqual(response.json.call_count, 1)
+
     def test_update_property_updates_remote_api_and_triggers_refresh(self):
         current = {
             "id": "prop-1",
@@ -641,6 +697,38 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
             self.service.upload_image("prop-1", UploadedFile(), "https://example.com", "admin@example.com")
 
         warning_mock.assert_called_once()
+
+    def test_upload_image_logs_association_http_error(self):
+        # A 4xx/5xx upstream response used to be silently ignored because the
+        # POST didn't call ``raise_for_status``. The local file is saved but
+        # upstream never learns about the URL, so the next refresh blanks it
+        # and the file becomes orphaned — make sure the failure surfaces.
+        file_bytes = io.BytesIO()
+        Image.new("RGB", (16, 9), color="yellow").save(file_bytes, format="PNG")
+        file_payload = file_bytes.getvalue()
+
+        class UploadedFile:
+            filename = "photo.png"
+            stream = io.BytesIO(file_payload)
+
+        error_response = Mock()
+        error_response.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
+
+        with patch("somewheria_app.services.properties.secrets.token_hex", return_value="httperr"), patch(
+            "somewheria_app.services.properties.url_for",
+            return_value="/static/uploads/prop-1_httperr.png",
+        ), patch(
+            "somewheria_app.services.properties.requests.post",
+            return_value=error_response,
+        ), patch.object(self.service.logger, "warning") as warning_mock, patch.object(
+            self.service,
+            "trigger_background_refresh",
+        ):
+            self.service.upload_image("prop-1", UploadedFile(), "https://example.com", "admin@example.com")
+
+        warning_mock.assert_called_once()
+        message = warning_mock.call_args.args[0]
+        self.assertIn("Failed to associate uploaded image", message)
 
 
 class CoverageInfrastructureTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

Two small but real defects in `somewheria_app/services/properties.py`:

1. **`create_property` double-parses and crashes on non-dict upstream bodies.**
   ```python
   new_id = response.json().get("id") or response.json().get("property_id") or ""
   ```
   `response.json()` was called twice (wasteful), and any non-dict / non-JSON
   body from upstream raised `AttributeError` / `JSONDecodeError` out of the
   admin POST, hitting the global crash handler. Now parsed once, with a
   defensive coerce-to-empty-dict fallback so the admin op still succeeds
   when upstream returns a quirky body — the property was created either
   way; we just lose the id in the change-log entry.

2. **`upload_image` photo-association POST silently swallowed HTTP errors.**
   The call had `timeout=20` and a connection-error `except`, but no
   `raise_for_status()`. A 4xx/5xx response left the local file on disk and
   recorded a successful `image_added` change-log entry while upstream never
   learned the URL. The next cache refresh then blanked the photo from the
   listing and the file became orphaned in `static/uploads/`. Added
   `raise_for_status()` inside the existing `try/except` so HTTP errors hit
   the same warning path as connection errors.

## Test plan

- [x] `python -m unittest discover` — 750 tests pass (4 new)
- [x] `ruff check .` — clean
- [x] New `test_create_property_returns_empty_id_when_response_is_not_a_dict`
- [x] New `test_create_property_returns_empty_id_when_response_body_is_invalid_json`
- [x] New `test_create_property_parses_response_json_only_once` (regression guard)
- [x] New `test_upload_image_logs_association_http_error`

---
_Generated by [Claude Code](https://claude.ai/code/session_01947csaCgsnB5EMhwGSW7mS)_