### PR TITLE
Stop trusting client-supplied X-Forwarded-For in the rate limiter

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -123,7 +123,7 @@ CSRF: required on all unsafe methods except `/google/callback` and static. Token
 
 These are enforced by `_RateLimiter` in `services/security.py`, in-memory per process. Behind multiple workers / instances each has its own bucket — the limits effectively multiply.
 
-`X-Forwarded-For` is trusted for the client IP if present. If you front with a proxy that doesn't sanitize this header, attackers can spoof IPs to evade the per-IP limits. Configure your proxy to overwrite `X-Forwarded-For`.
+Client IP is taken from `request.remote_addr`. By default `X-Forwarded-For` is **ignored** so an unauthenticated attacker can't rotate the header per request to skip the throttle. If you sit behind reverse proxies you control, set `TRUSTED_PROXY_COUNT=<N>` (number of hops) — `create_app()` wires Werkzeug's `ProxyFix` to strip exactly that many entries from the right of `X-Forwarded-For` and expose the original client IP as `remote_addr`. Leave it unset (or set to `0`) if the app accepts traffic directly.
 
 ## Zillow integration — pending credentials
 

--- a/somewheria_app/__init__.py
+++ b/somewheria_app/__init__.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 from flask import Flask, render_template, request
 from werkzeug.exceptions import HTTPException
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from .config import AppConfig
 from .routes.admin_routes import register_admin_routes
@@ -49,6 +50,22 @@ def create_app() -> Flask:
         static_folder=str(config.static_dir),
         static_url_path="/static",
     )
+    # When the operator declares a trusted proxy chain in front of the
+    # app, hand X-Forwarded-* parsing to Werkzeug's ProxyFix so it can
+    # strip exactly the configured number of hops and expose the original
+    # client IP as ``request.remote_addr``. Anything downstream
+    # (rate limiter, crash log) keys off ``remote_addr`` and therefore
+    # gains a real client IP. When count is 0, leave the WSGI stack
+    # untouched so a client-supplied X-Forwarded-For can NOT spoof the
+    # rate-limiter identity (the prior implementation honored the header
+    # unconditionally and was bypassable from any unauthenticated POST).
+    if config.trusted_proxy_count > 0:
+        app.wsgi_app = ProxyFix(
+            app.wsgi_app,
+            x_for=config.trusted_proxy_count,
+            x_proto=config.trusted_proxy_count,
+            x_host=config.trusted_proxy_count,
+        )
     app.secret_key = config.secret_key
     app.config["DISABLE_BACKGROUND_THREADS"] = config.disable_background_threads
     app.config["SHOW_REQUEST_LOGS"] = True
@@ -180,7 +197,11 @@ def create_app() -> Flask:
             method = request.method
             endpoint = request.endpoint or ""
             ua = request.headers.get("User-Agent", "")
-            remote = request.headers.get("X-Forwarded-For", request.remote_addr or "")
+            # ``remote_addr`` is the source of truth: it's either the direct
+            # TCP peer or — when TRUSTED_PROXY_COUNT is set — the ProxyFix
+            # normalized client IP. Reading X-Forwarded-For directly would
+            # log a header an unauthenticated visitor controls.
+            remote = request.remote_addr or ""
         except Exception:
             path, method, endpoint = "(unknown)", "(unknown)", ""
             ua, remote = "(unknown)", "(unknown)"

--- a/somewheria_app/config.py
+++ b/somewheria_app/config.py
@@ -13,6 +13,17 @@ def _csv_env(name: str) -> list[str]:
     return [item.strip().lower() for item in os.getenv(name, "").split(",") if item.strip()]
 
 
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
 @dataclass
 class AppConfig:
     base_dir: Path = field(default_factory=lambda: Path(__file__).resolve().parent.parent)
@@ -38,6 +49,18 @@ class AppConfig:
     )
     use_sqlite_storage: bool = field(
         default_factory=lambda: os.getenv("USE_SQLITE_STORAGE", "0") == "1"
+    )
+    # Number of trusted reverse-proxy hops in front of the app. When 0
+    # (default) the rate limiter and crash log use ``request.remote_addr``
+    # directly and ignore client-supplied ``X-Forwarded-For``, which
+    # otherwise lets an attacker rotate that header to bypass per-IP
+    # throttles. Set to the number of proxies you control (e.g. 1 for a
+    # single nginx in front) so Werkzeug's ProxyFix can strip exactly
+    # that many entries from the right of ``X-Forwarded-For`` and expose
+    # the real client IP as ``remote_addr``. A non-numeric value falls
+    # back to 0 — fail closed rather than fail open.
+    trusted_proxy_count: int = field(
+        default_factory=lambda: _int_env("TRUSTED_PROXY_COUNT", 0)
     )
     authorized_users: list[str] = field(default_factory=lambda: _csv_env("AUTHORIZED_USERS"))
     admin_users: list[str] = field(default_factory=lambda: _csv_env("ADMIN_USERS"))

--- a/somewheria_app/services/security.py
+++ b/somewheria_app/services/security.py
@@ -168,9 +168,14 @@ _limiter = _RateLimiter()
 
 
 def _client_ip() -> str:
-    forwarded = request.headers.get("X-Forwarded-For", "")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
+    # ``remote_addr`` is the only client identifier we'll trust here.
+    # When the app sits behind a proxy chain the operator declared via
+    # ``TRUSTED_PROXY_COUNT`` (see ``somewheria_app/__init__.py``),
+    # Werkzeug's ProxyFix has already rewritten ``remote_addr`` to the
+    # actual client. When no proxy is declared we MUST NOT read
+    # ``X-Forwarded-For`` directly: anyone making an unauthenticated POST
+    # to a rate-limited route can rotate that header per request and
+    # gain a fresh bucket each time, defeating the throttle entirely.
     return request.remote_addr or "0.0.0.0"
 
 

--- a/test_services.py
+++ b/test_services.py
@@ -1273,6 +1273,151 @@ class RateLimiterTestCase(unittest.TestCase):
         self.assertIn("active", limiter._hits)
 
 
+class ClientIpResolutionTestCase(unittest.TestCase):
+    """`_client_ip` keys the rate limiter. If it honors a client-supplied
+    ``X-Forwarded-For`` without a trusted-proxy guard, an attacker can rotate
+    the header per request to gain a fresh bucket and bypass throttles."""
+
+    def _build_app(self, trusted_proxy_count=0):
+        from flask import Flask
+        from werkzeug.middleware.proxy_fix import ProxyFix
+
+        app = Flask(__name__)
+        app.secret_key = "test"
+        if trusted_proxy_count > 0:
+            app.wsgi_app = ProxyFix(
+                app.wsgi_app,
+                x_for=trusted_proxy_count,
+                x_proto=trusted_proxy_count,
+                x_host=trusted_proxy_count,
+            )
+        return app
+
+    def _resolve(self, app, environ_overrides=None, headers=None):
+        from somewheria_app.services.security import _client_ip
+
+        overrides = {"REMOTE_ADDR": "10.0.0.1"}
+        if environ_overrides:
+            overrides.update(environ_overrides)
+        with app.test_request_context(
+            "/", environ_overrides=overrides, headers=headers or {}
+        ):
+            return _client_ip()
+
+    def test_default_ignores_x_forwarded_for(self):
+        app = self._build_app(trusted_proxy_count=0)
+        ip = self._resolve(
+            app,
+            headers={"X-Forwarded-For": "1.2.3.4, 5.6.7.8"},
+        )
+        # Header is attacker-controlled when no proxy is declared; we
+        # MUST fall back to the actual TCP peer.
+        self.assertEqual(ip, "10.0.0.1")
+
+    def test_default_uses_remote_addr_when_no_header(self):
+        app = self._build_app(trusted_proxy_count=0)
+        ip = self._resolve(app)
+        self.assertEqual(ip, "10.0.0.1")
+
+    def test_default_handles_missing_remote_addr(self):
+        app = self._build_app(trusted_proxy_count=0)
+        ip = self._resolve(app, environ_overrides={"REMOTE_ADDR": None})
+        # Werkzeug stores None as missing; _client_ip falls back to the
+        # explicit sentinel so the bucket key is never empty.
+        self.assertEqual(ip, "0.0.0.0")
+
+    def test_default_does_not_let_spoofed_header_split_buckets(self):
+        app = self._build_app(trusted_proxy_count=0)
+        first = self._resolve(app, headers={"X-Forwarded-For": "1.1.1.1"})
+        second = self._resolve(app, headers={"X-Forwarded-For": "2.2.2.2"})
+        # An attacker rotating XFF from a single TCP peer must hit the
+        # same limiter bucket — otherwise the rate limit is bypassable.
+        self.assertEqual(first, second)
+        self.assertEqual(first, "10.0.0.1")
+
+    def _resolve_via_wsgi(self, app, headers=None, remote_addr="10.0.0.99"):
+        # ProxyFix runs at WSGI middleware layer, so test_request_context
+        # bypasses it. Drive the test client instead — it executes the
+        # full middleware chain before the view runs.
+        from somewheria_app.services.security import _client_ip
+
+        captured = {}
+
+        @app.route("/__client_ip__")
+        def _capture():
+            captured["ip"] = _client_ip()
+            return "ok"
+
+        client = app.test_client()
+        client.get(
+            "/__client_ip__",
+            headers=headers or {},
+            environ_overrides={"REMOTE_ADDR": remote_addr},
+        )
+        return captured["ip"]
+
+    def test_with_trusted_proxy_extracts_real_client_from_xff(self):
+        # Operator declared ONE trusted proxy in front of the app.
+        # ProxyFix strips the rightmost hop and exposes the original
+        # client IP as remote_addr; _client_ip should surface that.
+        app = self._build_app(trusted_proxy_count=1)
+        ip = self._resolve_via_wsgi(
+            app,
+            headers={"X-Forwarded-For": "203.0.113.5"},
+        )
+        self.assertEqual(ip, "203.0.113.5")
+
+    def test_with_trusted_proxy_falls_back_when_header_missing(self):
+        app = self._build_app(trusted_proxy_count=1)
+        ip = self._resolve_via_wsgi(app)
+        # No header means we still see the proxy IP — not great, but the
+        # expected behavior; the operator's job is to ensure the proxy
+        # always sets X-Forwarded-For.
+        self.assertEqual(ip, "10.0.0.99")
+
+
+class TrustedProxyConfigTestCase(unittest.TestCase):
+    """``TRUSTED_PROXY_COUNT`` parsing must fail closed: any non-numeric or
+    negative value reverts to 0 (ignore X-Forwarded-For) rather than
+    enabling proxy trust with an undefined hop count."""
+
+    def _load_count(self, raw):
+        import os
+        from importlib import reload
+
+        import somewheria_app.config as cfg
+
+        previous = os.environ.get("TRUSTED_PROXY_COUNT")
+        if raw is None:
+            os.environ.pop("TRUSTED_PROXY_COUNT", None)
+        else:
+            os.environ["TRUSTED_PROXY_COUNT"] = raw
+        try:
+            reload(cfg)
+            return cfg.AppConfig().trusted_proxy_count
+        finally:
+            if previous is None:
+                os.environ.pop("TRUSTED_PROXY_COUNT", None)
+            else:
+                os.environ["TRUSTED_PROXY_COUNT"] = previous
+            reload(cfg)
+
+    def test_unset_defaults_to_zero(self):
+        self.assertEqual(self._load_count(None), 0)
+
+    def test_blank_defaults_to_zero(self):
+        self.assertEqual(self._load_count("   "), 0)
+
+    def test_non_numeric_defaults_to_zero(self):
+        self.assertEqual(self._load_count("nginx"), 0)
+
+    def test_negative_defaults_to_zero(self):
+        self.assertEqual(self._load_count("-1"), 0)
+
+    def test_valid_integer_parses(self):
+        self.assertEqual(self._load_count("2"), 2)
+
+
 class CsrfTokenExtractionTestCase(unittest.TestCase):
     """``_extract_submitted_token`` must always return a string so the
     ``secrets.compare_digest`` check in ``_csrf_before_request`` can never


### PR DESCRIPTION
## Summary

- `_client_ip()` previously honored the first entry of `X-Forwarded-For` unconditionally, so an unauthenticated client could rotate the header per request and bypass all per-IP throttles (`/register`, `/tickets/new`, lead capture, scheduling, etc.).
- Switch `_client_ip()` to `request.remote_addr` alone. Add `TRUSTED_PROXY_COUNT` config (env var, default `0`) and wire Werkzeug's `ProxyFix` in `create_app()` when it's set so operators behind a known proxy chain get the real client IP exposed as `remote_addr`. Default is fail-closed.
- Same fix applied to the crash-email log line, which was logging an attacker-controlled header.

## Why it matters

`docs/RUNBOOK.md` already acknowledged the prior behavior was spoofable ("attackers can spoof IPs to evade the per-IP limits") but offloaded the mitigation to operators. With `ProxyFix` wiring + a single env var, the default deployment is now secure and the proxy case is opt-in.

## Test plan

- [x] `python -m unittest discover` — 757 tests pass
- [x] `ruff check .` — clean
- [x] New tests in `test_services.py`:
  - `ClientIpResolutionTestCase` — default ignores `X-Forwarded-For`; same IP returned regardless of rotated header; ProxyFix mode extracts the real client IP via the WSGI middleware chain
  - `TrustedProxyConfigTestCase` — `TRUSTED_PROXY_COUNT` falls back to `0` for unset / blank / non-numeric / negative values


---
_Generated by [Claude Code](https://claude.ai/code/session_01NtGzynjjZojtuZ9qxQTZiZ)_