### PR TITLE
Reject userinfo, control chars, and backslashes in tour URLs

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -101,6 +101,22 @@ def sanitize_tour_url(raw: str) -> str:
     value = raw.strip()[:2048]
     if not value:
         return ""
+    # Reject anything below 0x20 (NUL, TAB, CR, LF, …) or DEL (0x7F). Browsers
+    # and urllib disagree on how to handle embedded control characters: urlparse
+    # silently strips a stray "\n" or "\t" from the netloc, but the raw value we
+    # return still carries it. Embedding that in an iframe ``src`` attribute is
+    # a known URL-spoofing vector — different parsers cut the URL at different
+    # points. Rejecting at the boundary keeps the value byte-identical to what
+    # both we and the browser will parse.
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+        return ""
+    # Reject backslashes anywhere in the URL. Python's urlparse keeps them
+    # in the path/netloc as-is, but some browsers normalize "\" to "/" before
+    # parsing, which lets ``https://evil.com\@target.com`` resolve to either
+    # ``evil.com`` or ``target.com`` depending on the consumer. Refusing them
+    # avoids the ambiguity entirely.
+    if "\\" in value:
+        return ""
     try:
         parsed = urlparse(value)
     except ValueError:
@@ -109,6 +125,12 @@ def sanitize_tour_url(raw: str) -> str:
     if scheme not in _ALLOWED_TOUR_SCHEMES:
         return ""
     if not parsed.netloc:
+        return ""
+    # Reject URLs that embed credentials in the authority section
+    # (``https://user:pass@host/``). Modern browsers warn or refuse outright,
+    # but an iframe ``src`` with userinfo can still leak through and is never
+    # legitimate for a 3D-tour embed — Matterport / Kuula links never use it.
+    if "@" in parsed.netloc:
         return ""
     return value
 

--- a/test_services.py
+++ b/test_services.py
@@ -1504,6 +1504,39 @@ class TourUrlSanitizationTestCase(unittest.TestCase):
         ):
             self.assertEqual(sanitize_tour_url(hostile), "")
 
+    def test_sanitize_rejects_userinfo_in_authority(self):
+        from somewheria_app.services.properties import sanitize_tour_url
+
+        for hostile in (
+            "https://user:pass@evil.com/show",
+            "https://user@evil.com/show",
+            "http://admin:hunter2@matterport.com/show",
+        ):
+            self.assertEqual(sanitize_tour_url(hostile), "")
+
+    def test_sanitize_rejects_control_characters(self):
+        from somewheria_app.services.properties import sanitize_tour_url
+
+        for hostile in (
+            "https://example.com\n/show",
+            "https://example.com\r\n/show",
+            "https://example.com\t/show",
+            "https://example.com\x00.evil.com/show",
+            "https://example.com\x1f/show",
+            "https://example.com\x7f/show",
+        ):
+            self.assertEqual(sanitize_tour_url(hostile), "")
+
+    def test_sanitize_rejects_backslashes(self):
+        from somewheria_app.services.properties import sanitize_tour_url
+
+        for hostile in (
+            "https://evil.com\\@target.com/show",
+            "https://example.com/\\evil/show",
+            "https:\\\\example.com/show",
+        ):
+            self.assertEqual(sanitize_tour_url(hostile), "")
+
     def test_property_payload_from_form_includes_sanitized_tour_url(self):
         notifications = Mock()
         config = SimpleNamespace(


### PR DESCRIPTION
## Summary

`sanitize_tour_url` (`somewheria_app/services/properties.py`) gated by scheme and a non-empty netloc, but let through three browser-quirky URL shapes that all reach the iframe `src` and the upstream property API verbatim:

- **Userinfo in the authority** — `https://user:pass@evil.com/`. Modern browsers warn but still load; iframe embeds with credentials are never legitimate for a Matterport/Kuula tour.
- **ASCII control characters** — newline, tab, NUL, DEL anywhere in the URL. `urlparse` silently strips a stray `\n`/`\t` from the netloc, but the raw string we returned still carried it. Different parsers (urllib vs browsers vs proxies) then cut the URL at different points — a known URL-spoofing vector.
- **Backslashes anywhere** — some browsers normalize `\` to `/` before parsing, so `https://evil.com\@target.com` resolves to `evil.com` or `target.com` depending on the consumer.

Rejecting these at the boundary keeps the value byte-identical to what every downstream parser sees. The existing positive path (Matterport/Kuula https URLs) is unchanged.

## Test plan

- [x] `python -m unittest discover` — 760 tests pass (3 new ones in `TourUrlSanitizationTestCase`)
- [x] `ruff check somewheria_app/services/properties.py test_services.py` — clean
- [x] New tests cover userinfo, control chars (`\n`, `\r\n`, `\t`, `\x00`, `\x1f`, `\x7f`), and backslash shapes


---
_Generated by [Claude Code](https://claude.ai/code/session_0118ABpHa8A6mMqY35SSBeig)_