### PR TITLE
Avoid re-serializing the photo cache to compare refresh results

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -1,7 +1,6 @@
 import base64
 import concurrent.futures
 import copy
-import json
 import os
 import re
 import secrets
@@ -326,10 +325,22 @@ class PropertyService:
                 try:
                     latest_properties = self.fetch_all_properties()
                     with self.cache_lock:
-                        current_snapshot = copy.deepcopy(self.cache)
-                        if json.dumps(current_snapshot, sort_keys=True) == json.dumps(latest_properties, sort_keys=True):
+                        # Compare the live cache to the latest fetch directly.
+                        # The prior implementation serialized both sides to
+                        # canonical JSON and compared the strings, which on a
+                        # cache full of base64-encoded photo data allocates and
+                        # walks tens of megabytes twice per admin-triggered
+                        # refresh. ``list``/``dict`` equality in Python 3 is
+                        # already order-independent for dict keys and walks
+                        # element-by-element with a short-circuit on the first
+                        # mismatch — same result, no large string allocation.
+                        if self.cache == latest_properties:
                             self.logger.info("Refresh completed with no property changes")
                             return
+                        # Snapshot the pre-write cache for the change-log diff.
+                        # Deep-copied so ``_build_change_log`` doesn't see the
+                        # post-assignment cache state via aliasing.
+                        current_snapshot = copy.deepcopy(self.cache)
                         log_details = self._build_change_log(current_snapshot, latest_properties)
                         self.cache = latest_properties
                     self.notifications.log_site_change(actor_email, "properties_cache_updated", log_details)

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -250,6 +250,20 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.notifications.log_site_change.assert_not_called()
         info_mock.assert_called_once()
 
+    def test_refresh_with_change_log_treats_dict_key_order_as_equal(self):
+        # The "no-change" short-circuit compares the live cache to the
+        # upstream fetch with Python ``==`` rather than serializing both
+        # sides to canonical JSON. Dict equality in Python 3 is already
+        # order-independent, so a property whose fields come back in a
+        # different key order from upstream must NOT register as a change
+        # and trigger a phantom ``properties_cache_updated`` audit entry.
+        self.service.cache = [{"id": "prop-1", "name": "Maple", "rent": "2000"}]
+        latest = [{"rent": "2000", "id": "prop-1", "name": "Maple"}]
+        with patch.object(self.service, "fetch_all_properties", return_value=latest):
+            self.service._refresh_with_change_log("admin@example.com")
+
+        self.notifications.log_site_change.assert_not_called()
+
     def test_refresh_with_change_log_updates_cache_and_logs_change(self):
         self.service.cache = [{"id": "prop-1", "name": "Old"}]
         latest = [{"id": "prop-1", "name": "New"}]


### PR DESCRIPTION
## Summary

`PropertyService._refresh_with_change_log` decided whether the upstream
fetch matched the live cache by serializing both sides to canonical JSON
(`json.dumps(..., sort_keys=True)`) and comparing the strings. With each
cached property carrying base64-encoded photos, that allocates and walks
tens of megabytes twice on every admin-triggered refresh.

This swaps the string compare for direct `list`/`dict` equality. Python
dict `__eq__` is already order-independent and walks element-by-element
with a short-circuit on the first mismatch — same semantics, no large
string allocation.

## Changes

- `somewheria_app/services/properties.py`: drop the `json.dumps`
  round-trip in the "no-change" short-circuit; compare `self.cache`
  directly against `latest_properties`. Defer the `deepcopy` until we
  know we'll need a pre-write snapshot for `_build_change_log`. Drop
  the now-unused `import json`.
- `test_coverage_full.py`: add a regression test that pins down the
  order-independent short-circuit so a future change can't quietly
  reintroduce a phantom `properties_cache_updated` audit entry when
  upstream returns the same property with reordered fields.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 778 tests pass
- [x] `ruff check somewheria_app/` — clean
- [x] New test `test_refresh_with_change_log_treats_dict_key_order_as_equal` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDtKEF5Yrhk8DKLyudXuua)_