### PR TITLE
Fix analytics UTC label drift and 404 on missing ticket update

### DIFF
--- a/somewheria_app/routes/ticket_routes.py
+++ b/somewheria_app/routes/ticket_routes.py
@@ -257,7 +257,13 @@ def admin_ticket_update(ticket_id: str):
     }
     # Trim unset keys so the service only considers fields the form submitted.
     updates = {k: v for k, v in updates.items() if v is not None}
-    services.tickets.update_ticket(ticket_id, updates, _actor_email())
+    # 404 when the ticket has been deleted (or the id was mistyped) so the
+    # admin sees the miss instead of a silent redirect to a broken detail
+    # page. ``update_ticket`` returns None on a miss; the other ticket
+    # routes (detail, add-note, toggle-email) already 404 in this case.
+    result = services.tickets.update_ticket(ticket_id, updates, _actor_email())
+    if result is None:
+        return render_template("404.html", title="Ticket Not Found"), 404
     return redirect(url_for("ticket_detail", ticket_id=ticket_id))
 
 

--- a/somewheria_app/services/analytics.py
+++ b/somewheria_app/services/analytics.py
@@ -120,7 +120,14 @@ class AnalyticsTracker:
         order ending with the current month.
         """
         months = max(1, int(months))
-        today = datetime.date.today()
+        # Labels are computed from UTC "today" because entries in
+        # site_changes.log are written with utcnow_iso() and bucketed by the
+        # UTC ``YYYY-MM`` prefix. Using ``date.today()`` (local) here would
+        # silently drop the first hours of a new UTC month whenever the
+        # server's local date lags UTC (or the last hours of a UTC month
+        # when local leads UTC) -- the entries land in a month label that
+        # isn't in the window yet.
+        today = datetime.datetime.now(datetime.timezone.utc).date()
         labels: list[str] = []
         # Build labels in chronological order ending on the current month.
         year, month = today.year, today.month

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -1262,6 +1262,46 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    def test_admin_ticket_update_returns_404_when_ticket_missing(self):
+        # The other ticket routes (detail, add-note, toggle-email) already
+        # 404 on a miss. Before this fix admin_ticket_update silently
+        # redirected to a broken detail page whenever the ticket had been
+        # deleted or the id was mistyped, hiding the mistake from admins.
+        self.login_as("admin")
+
+        with patch.object(
+            self.services.tickets, "update_ticket", return_value=None
+        ) as mock_update:
+            response = self.client.post(
+                "/admin/tickets/nonexistent-id",
+                data={"status": "in_progress"},
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 404)
+        mock_update.assert_called_once()
+
+    def test_admin_ticket_update_redirects_on_success(self):
+        self.login_as("admin")
+
+        sample_ticket = {
+            "id": "abc123",
+            "title": "Leaky",
+            "status": "in_progress",
+            "priority": "high",
+        }
+        with patch.object(
+            self.services.tickets, "update_ticket", return_value=sample_ticket
+        ):
+            response = self.client.post(
+                "/admin/tickets/abc123",
+                data={"status": "in_progress"},
+                follow_redirects=False,
+            )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/tickets/abc123", response.headers["Location"])
+
     def test_admin_contracts_export_csv_neutralizes_formula_injection(self):
         # A malicious admin or hand-edited storage could record a property
         # name beginning with `=` (or `+`, `-`, `@`). When the resulting CSV

--- a/test_services.py
+++ b/test_services.py
@@ -1210,6 +1210,74 @@ class AnalyticsPruningTestCase(unittest.TestCase):
         self.assertEqual(len(tracker.errors), 0)
 
 
+class RecentListingActivityTestCase(unittest.TestCase):
+    """`recent_listing_activity` buckets entries by the UTC ``YYYY-MM`` prefix
+    of the change-log timestamp (`utcnow_iso()` writes Z-suffixed UTC). Labels
+    must also come from UTC so a fresh entry logged just after the UTC month
+    rolls over still lands in the current-window buckets when the server's
+    local calendar hasn't rolled yet — otherwise the current month's data is
+    silently dropped from the admin chart."""
+
+    def _tracker(self, tmpdir: Path):
+        from somewheria_app.services.analytics import AnalyticsTracker
+
+        change_log = tmpdir / "site_changes.log"
+        config = SimpleNamespace(change_log_file=change_log)
+        return AnalyticsTracker(analytics_days=7, config=config), change_log
+
+    def test_labels_use_utc_not_local_time(self):
+        # Simulate a server whose local calendar reads 2026-06-30 while
+        # UTC has already rolled over to 2026-07-01. Under the old code,
+        # ``date.today()`` returned the local date, labels ended at
+        # "2026-06", and any entry timestamped with the current UTC month
+        # ("2026-07-...Z") fell outside the label set and was silently
+        # dropped from the admin chart.
+        import somewheria_app.services.analytics as analytics_module
+
+        real_datetime_module = analytics_module.datetime
+
+        class _FrozenDate(real_datetime_module.date):
+            @classmethod
+            def today(cls):
+                # Local calendar still reads the previous UTC month.
+                return real_datetime_module.date(2026, 6, 30)
+
+        class _FrozenDatetime(real_datetime_module.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                # UTC has already rolled over to the next month.
+                return real_datetime_module.datetime(
+                    2026, 7, 1, 6, 30, 0,
+                    tzinfo=tz or real_datetime_module.timezone.utc,
+                )
+
+        with tempfile.TemporaryDirectory() as td:
+            tracker, change_log = self._tracker(Path(td))
+            change_log.write_text(
+                '{"timestamp": "2026-07-01T06:31:00Z", "action": "property_created", "extra": {}}\n'
+                '{"timestamp": "2026-06-30T23:59:00Z", "action": "property_created", "extra": {}}\n',
+                encoding="utf-8",
+            )
+
+            fake_module = SimpleNamespace(
+                date=_FrozenDate,
+                datetime=_FrozenDatetime,
+                timedelta=real_datetime_module.timedelta,
+                timezone=real_datetime_module.timezone,
+            )
+            with patch.object(analytics_module, "datetime", fake_module):
+                result = tracker.recent_listing_activity(months=3)
+
+        # Current-window labels must include the current UTC month.
+        self.assertIn("2026-07", result["months"])
+        self.assertIn("2026-06", result["months"])
+        # And the UTC-July entry must be counted, not silently dropped.
+        july_idx = result["months"].index("2026-07")
+        june_idx = result["months"].index("2026-06")
+        self.assertEqual(result["created"][july_idx], 1)
+        self.assertEqual(result["created"][june_idx], 1)
+
+
 class RateLimiterTestCase(unittest.TestCase):
     def _make_limiter(self):
         from somewheria_app.services.security import _RateLimiter


### PR DESCRIPTION
## Summary

Two small, contained backend fixes discovered during the daily maintenance sweep.

### 1. `AnalyticsTracker.recent_listing_activity` UTC label drift

`recent_listing_activity()` builds the month labels ending with the current month from `datetime.date.today()` — the server's **local** date. Entries in `site_changes.log` are written via `utcnow_iso()` (Z-suffixed **UTC**), and bucketing is done from the entry's `timestamp[:7]` (UTC `YYYY-MM`).

Near midnight when the server's local date and UTC date straddle the month boundary, entries logged with the current UTC month end up in a label that isn't in the window yet, and are silently dropped from the admin listing-activity chart. `services/timeutil.py` already flagged this exact bucket-slice mismatch as the reason `utcnow_iso` was introduced (commit `fc05b4a`); this brings the label side of the pair into UTC as well.

Fix: compute the "current month" from UTC (`datetime.now(timezone.utc).date()`) so the labels and the bucket keys share the same calendar.

New unit test freezes local date at `2026-06-30` while UTC reads `2026-07-01 06:30` and asserts the `2026-07-01T06:31:00Z` entry lands in the current window. The test fails on the pre-fix code and passes after.

### 2. `admin_ticket_update` silently redirects when the ticket doesn't exist

The admin update endpoint (`POST /admin/tickets/<ticket_id>`) passed `ticket_id` straight to `update_ticket`, which returns `None` on a miss, then redirected the admin to a detail page that would itself 404. Every other ticket route (detail, add-note, toggle-email) already 404s on a missing ticket — bring the admin update endpoint into line so admins see the mistake instead of chasing a dead redirect.

Two new route tests cover the 404-on-miss path and the redirect-on-success path.

## Test plan

- [x] `python -m unittest discover` — 781 tests pass, 1 skipped (baseline was 778 pass, 1 skipped; +3 new tests)
- [x] `ruff check .` — clean
- [x] Confirmed the new analytics test fails on pre-fix code (see commit)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aup5jR1QqgQYTMLostKphN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aup5jR1QqgQYTMLostKphN)_