### PR TITLE
Avoid deep-copying property cache just to count entries

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -228,7 +228,7 @@ def renter_dashboard():
 @high_admin_required
 def analytics_dashboard():
     services = get_services()
-    metrics, chart_data = services.analytics.dashboard_data(len(services.properties.get_cached_properties()))
+    metrics, chart_data = services.analytics.dashboard_data(services.properties.property_count())
     return render_template(
         "analytics_dashboard.html",
         user=get_current_user(),
@@ -242,7 +242,7 @@ def analytics_dashboard():
 def admin_status():
     services = get_services()
     config = services.config
-    property_count = len(services.properties.get_cached_properties())
+    property_count = services.properties.property_count()
     pending_registrations = services.storage.get_pending_registrations()
     user_roles = services.storage.get_user_roles()
     registered_routes = set(current_app.view_functions.keys())
@@ -481,7 +481,7 @@ def admin_dashboard_combined():
                     "user_added",
                     {"email": email, "role": new_role},
                 )
-    metrics, chart_data = services.analytics.dashboard_data(len(services.properties.get_cached_properties()))
+    metrics, chart_data = services.analytics.dashboard_data(services.properties.property_count())
     ticket_summary = services.tickets.summary()
     ticket_status_counts = services.tickets.status_counts()
     listing_activity = services.analytics.recent_listing_activity(months=12)

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -245,6 +245,15 @@ class PropertyService:
         with self.cache_lock:
             return copy.deepcopy(self.cache)
 
+    def property_count(self) -> int:
+        # Callers that only need the length (admin status/dashboard metrics)
+        # should reach for this instead of ``len(get_cached_properties())``.
+        # ``get_cached_properties`` deep-copies the full cache — including the
+        # base64-encoded photo payload attached to every property — which can
+        # be tens of MB per call for a routine dashboard render.
+        with self.cache_lock:
+            return len(self.cache)
+
     def get_cache_health(self) -> dict:
         """Snapshot of upstream-API refresh health for the admin status page.
 

--- a/test_services.py
+++ b/test_services.py
@@ -489,6 +489,24 @@ class PropertyServiceTestCase(unittest.TestCase):
 
         self.assertCountEqual(serialized[0]["amenities"], ["Parking", "Laundry"])
 
+    def test_property_count_returns_length_without_deep_copy(self):
+        # property_count() is the cheap alternative to
+        # ``len(get_cached_properties())`` — it must return the same length
+        # without deep-copying the underlying cache entries, which would
+        # otherwise allocate a fresh list and dict tree per admin dashboard
+        # render just to compute a size.
+        sentinel = {"id": "prop-1", "photos": ["data:image/jpeg;base64,AAAA"]}
+        self.service.cache = [sentinel, {"id": "prop-2"}]
+
+        self.assertEqual(self.service.property_count(), 2)
+        # The exact object must still be inside the cache — property_count
+        # must not have copied it.
+        self.assertIs(self.service.cache[0], sentinel)
+
+    def test_property_count_empty_cache(self):
+        self.service.cache = []
+        self.assertEqual(self.service.property_count(), 0)
+
     def test_normalize_property_applies_defaults(self):
         normalized = self.service.normalize_property({"name": "Maple House"}, "prop-1")
 


### PR DESCRIPTION
## Summary

Three admin routes (analytics dashboard, admin status, combined admin dashboard) only need the *number* of cached properties for a metric tile, but each was calling `len(services.properties.get_cached_properties())`.

`get_cached_properties()` runs `copy.deepcopy` on the whole cache — including the base64-encoded photo blobs attached to every property — so a routine admin page render was allocating a fresh dict tree for every listing (potentially tens of MB) purely to compute a size.

## Changes

- Added `PropertyService.property_count()` — a thin wrapper that returns `len(self.cache)` under `cache_lock`, no copying.
- Switched the three count-only call sites in `somewheria_app/routes/admin_routes.py` (`analytics_dashboard`, `admin_status`, `admin_dashboard_combined`) to the new method.
- Added two unit tests covering the new method (correct length, no copying of underlying cache entries, empty-cache case).

The existing `get_cached_properties()` accessor is unchanged and is still used by every caller that actually needs the property data.

## Test plan

- [x] `python -m unittest discover` — 783 tests pass (2 new, previous baseline 781)
- [ ] CI green on the PR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ed2gf2bfvzUeFbKvWGVpz)_