### PR TITLE
Avoid deep-copying a property just to read its name in ticket submissions

### DIFF
--- a/somewheria_app/routes/ticket_routes.py
+++ b/somewheria_app/routes/ticket_routes.py
@@ -78,9 +78,10 @@ def ticket_new_submit():
     property_id = (request.form.get("property_id") or "").strip()
     property_name = ""
     if property_id:
-        info = services.properties.get_property(property_id)
-        if info:
-            property_name = info.get("name", "")
+        # Read just the name from the cache rather than pulling back a
+        # deep-copy of the whole property record — the photos payload alone
+        # runs into the tens of MB when a property is fully populated.
+        property_name = services.properties.get_property_name(property_id) or ""
 
     payload = {
         "title": request.form.get("title", ""),

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -280,6 +280,20 @@ class PropertyService:
                     return copy.deepcopy(property_info)
         return None
 
+    def get_property_name(self, property_id: str) -> str | None:
+        # Callers that only need the display name (ticket submissions labeling
+        # a property, etc.) should reach for this instead of get_property().
+        # ``get_property`` deep-copies the whole record — including the
+        # base64-encoded photo payload, which can be tens of MB — just so the
+        # caller can read a single string field. Returning the name directly
+        # from the cache under the lock avoids that copy entirely.
+        with self.cache_lock:
+            for property_info in self.cache:
+                if property_info.get("id") == property_id:
+                    name = property_info.get("name")
+                    return name if isinstance(name, str) else None
+        return None
+
     def serialize_properties(self, properties: list[dict]) -> list[dict]:
         serialized = []
         for property_info in properties:

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -170,6 +170,37 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
 
         self.assertIsNone(self.service.get_property("missing"))
 
+    def test_get_property_name_returns_matching_name(self):
+        self.service.cache = [
+            {"id": "prop-1", "name": "Maple"},
+            {"id": "prop-2", "name": "Oak"},
+        ]
+
+        self.assertEqual(self.service.get_property_name("prop-2"), "Oak")
+
+    def test_get_property_name_returns_none_when_missing(self):
+        self.service.cache = [{"id": "prop-1", "name": "Maple"}]
+
+        self.assertIsNone(self.service.get_property_name("nope"))
+
+    def test_get_property_name_returns_none_when_name_is_not_a_string(self):
+        # Upstream can hand back ``null`` (or a misshaped value) for the name
+        # field; return None so callers don't render the literal "None".
+        self.service.cache = [{"id": "prop-1", "name": None}]
+
+        self.assertIsNone(self.service.get_property_name("prop-1"))
+
+    def test_get_property_name_does_not_deep_copy_the_record(self):
+        # The whole point of this method vs. get_property() is that it must
+        # avoid the deep-copy of the full record (photos payload can be
+        # tens of MB). Patch deepcopy to explode if anyone reaches for it.
+        self.service.cache = [{"id": "prop-1", "name": "Maple"}]
+        with patch(
+            "somewheria_app.services.properties.copy.deepcopy",
+            side_effect=AssertionError("get_property_name must not deep-copy"),
+        ):
+            self.assertEqual(self.service.get_property_name("prop-1"), "Maple")
+
     def test_trigger_background_refresh_starts_daemon_thread(self):
         thread_mock = Mock()
         with patch("somewheria_app.services.properties.threading.Thread", return_value=thread_mock) as thread_ctor:


### PR DESCRIPTION
## Summary

The ticket-submit route (`ticket_new_submit` in `somewheria_app/routes/ticket_routes.py`) reads back a property record via `services.properties.get_property(property_id)` solely to grab `info.get("name", "")`. `get_property()` deep-copies the full cached record, including the base64-encoded `photos` payload — the same tens-of-MB blob the recent `property_count()` fix ([#87 / cc20983](https://github.com/kltef/Somewheria-LLC-Rental-Property-Website/commit/cc20983)) trimmed out of the admin-dashboard path.

This PR mirrors that fix for the ticket path:

- Adds `PropertyService.get_property_name(property_id) -> str | None`, which returns the name string directly from under the cache lock — no `copy.deepcopy`, no photo-blob traversal, and coerces a non-string / null upstream `name` back to `None` so callers never render `"None"`.
- Switches `ticket_new_submit` to use it.
- Adds four unit tests covering: match, miss, null-name coercion, and a `deepcopy`-patching test that fails loudly if a future edit reintroduces a full-record copy on this path.

Same class of fix as #87, same rationale.

## Test plan

- [x] `python -m unittest discover` — 787 tests pass (+4 new, was 783)
- [x] `ruff check .` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_012kptS52oMt9jKfNf5PZP6p)_