### PR TITLE
Track upstream-API health on admin-triggered refreshes

### DIFF
--- a/somewheria_app/config.py
+++ b/somewheria_app/config.py
@@ -39,7 +39,13 @@ class AppConfig:
             "https://7pdnexz05a.execute-api.us-east-1.amazonaws.com/test",
         ).rstrip("/")
     )
-    cache_refresh_interval: int = field(default_factory=lambda: int(os.getenv("CACHE_REFRESH_INTERVAL", "60")))
+    # ``int()`` alone would raise ValueError at startup on a mistyped env value
+    # (``CACHE_REFRESH_INTERVAL=sixty``) and refuse to boot. ``_int_env``
+    # matches the ``TRUSTED_PROXY_COUNT`` contract: blank / non-numeric /
+    # negative all fall back to the default rather than crashing.
+    cache_refresh_interval: int = field(
+        default_factory=lambda: _int_env("CACHE_REFRESH_INTERVAL", 60)
+    )
     analytics_days: int = 7
     email_sender: str = "anthony.j.ekberg@gmail.com"
     email_recipient: str = "anthony@ekbergproperties.com"

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -331,8 +331,27 @@ class PropertyService:
                         self.REFRESH_COALESCE_SECONDS,
                     )
                     return
+                started = time.monotonic()
                 try:
-                    latest_properties = self.fetch_all_properties()
+                    try:
+                        latest_properties = self.fetch_all_properties()
+                    except Exception as fetch_exc:
+                        # Mirror refresh_cache's health-tracking on failure so
+                        # /admin/status shows the outage regardless of which
+                        # code path attempted the refresh. Without this,
+                        # admin-triggered refreshes could silently regress the
+                        # status page to "never attempted" or leave a stale
+                        # "succeeded" from a much earlier /for-rent hit.
+                        self._last_refresh_ok = False
+                        self._last_refresh_error = str(fetch_exc)
+                        raise
+                    # Upstream reachable — record the success before mutating
+                    # (or short-circuiting on) the local cache so the admin
+                    # status page reflects real upstream connectivity even
+                    # when the fetch happened to return an identical listing.
+                    self._last_refresh_ok = True
+                    self._last_refresh_error = None
+                    self._last_success_at = datetime.now(timezone.utc)
                     with self.cache_lock:
                         # Compare the live cache to the latest fetch directly.
                         # The prior implementation serialized both sides to
@@ -364,8 +383,11 @@ class PropertyService:
                     # followers (a ``/for-rent`` hit or another trigger)
                     # arriving within the coalesce window don't immediately
                     # re-hit the same dead endpoint — mirrors the refresh_cache
-                    # contract.
+                    # contract. Also stamp the observed fanout duration so
+                    # the admin status page's "creeping toward 29s" check
+                    # covers both refresh paths.
                     self._last_refresh_monotonic = time.monotonic()
+                    self._last_refresh_seconds = time.monotonic() - started
         except Exception as exc:
             self.logger.error("On-demand refresh failed: %s", exc)
         finally:

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -431,6 +431,66 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(self.service.cache, [{"id": "prop-1", "name": "Maple"}])
         self.notifications.log_site_change.assert_not_called()
 
+    def test_refresh_with_change_log_records_success_health(self):
+        # ``get_cache_health`` powers /admin/status. Before this fix, an
+        # admin-triggered refresh (property_created / property_updated /
+        # image_added / …) never touched ``_last_success_at`` /
+        # ``_last_refresh_ok`` / ``_last_refresh_seconds``, so the status
+        # page showed "never refreshed yet" until a public /for-rent hit
+        # exercised ``refresh_cache`` — misleading during an admin-only
+        # burst of activity.
+        self.service.cache = [{"id": "prop-1", "name": "Old"}]
+        with patch.object(
+            self.service,
+            "fetch_all_properties",
+            return_value=[{"id": "prop-1", "name": "New"}],
+        ):
+            self.service._refresh_with_change_log("admin@example.com")
+
+        health = self.service.get_cache_health()
+        self.assertIs(health["last_attempt_ok"], True)
+        self.assertIsNone(health["last_error"])
+        self.assertIsNotNone(health["last_success_at"])
+        self.assertIsNotNone(health["last_refresh_seconds"])
+
+    def test_refresh_with_change_log_records_success_even_when_unchanged(self):
+        # The "no-op, cache identical" path also successfully reached upstream —
+        # it just happened to find no diff. The status page must still see
+        # this as a successful refresh, otherwise a steady-state site with
+        # no property changes but frequent admin activity would drift the
+        # displayed health toward "stale" purely because nothing changed.
+        self.service.cache = [{"id": "prop-1", "name": "Maple"}]
+        with patch.object(
+            self.service,
+            "fetch_all_properties",
+            return_value=[{"id": "prop-1", "name": "Maple"}],
+        ):
+            self.service._refresh_with_change_log("admin@example.com")
+
+        health = self.service.get_cache_health()
+        self.assertIs(health["last_attempt_ok"], True)
+        self.assertIsNone(health["last_error"])
+        self.assertIsNotNone(health["last_success_at"])
+
+    def test_refresh_with_change_log_records_failure_health(self):
+        # A failed admin-triggered refresh must surface the error to
+        # /admin/status, mirroring refresh_cache's error path. Without this,
+        # an ongoing upstream outage during admin activity would keep the
+        # status page pinned to the last public /for-rent success.
+        self.service._last_refresh_ok = True
+        self.service._last_refresh_error = None
+        with patch.object(
+            self.service,
+            "fetch_all_properties",
+            side_effect=RuntimeError("upstream 502"),
+        ):
+            self.service._refresh_with_change_log("admin@example.com")
+
+        health = self.service.get_cache_health()
+        self.assertIs(health["last_attempt_ok"], False)
+        self.assertIn("upstream 502", health["last_error"])
+        self.assertIsNotNone(health["last_refresh_seconds"])
+
     def test_fetch_all_properties_preserves_cache_when_every_record_fetch_fails(self):
         # IDs listing succeeds, but every per-property details fetch fails
         # (transient 5xx on the details endpoint). Without the guard,

--- a/test_services.py
+++ b/test_services.py
@@ -1504,6 +1504,54 @@ class TrustedProxyConfigTestCase(unittest.TestCase):
         self.assertEqual(self._load_count("2"), 2)
 
 
+class CacheRefreshIntervalConfigTestCase(unittest.TestCase):
+    """``CACHE_REFRESH_INTERVAL`` must tolerate malformed env values the same
+    way ``TRUSTED_PROXY_COUNT`` does: the app has to boot even when an
+    operator typos the number, rather than raising ValueError inside the
+    dataclass ``default_factory`` and crashing at startup."""
+
+    def _load_interval(self, raw):
+        import os
+        from importlib import reload
+
+        import somewheria_app.config as cfg
+
+        previous = os.environ.get("CACHE_REFRESH_INTERVAL")
+        if raw is None:
+            os.environ.pop("CACHE_REFRESH_INTERVAL", None)
+        else:
+            os.environ["CACHE_REFRESH_INTERVAL"] = raw
+        try:
+            reload(cfg)
+            return cfg.AppConfig().cache_refresh_interval
+        finally:
+            if previous is None:
+                os.environ.pop("CACHE_REFRESH_INTERVAL", None)
+            else:
+                os.environ["CACHE_REFRESH_INTERVAL"] = previous
+            reload(cfg)
+
+    def test_unset_defaults_to_sixty(self):
+        self.assertEqual(self._load_interval(None), 60)
+
+    def test_blank_defaults_to_sixty(self):
+        self.assertEqual(self._load_interval("   "), 60)
+
+    def test_non_numeric_defaults_to_sixty(self):
+        # Before the fix, ``int("sixty")`` raised ValueError inside the
+        # dataclass default_factory and prevented ``create_app()`` from
+        # succeeding — the whole process failed to boot on a mistyped env.
+        self.assertEqual(self._load_interval("sixty"), 60)
+
+    def test_negative_defaults_to_sixty(self):
+        # ``_int_env`` treats negatives as invalid so the polling loop
+        # (and admin status card) never see a nonsense window.
+        self.assertEqual(self._load_interval("-5"), 60)
+
+    def test_valid_integer_parses(self):
+        self.assertEqual(self._load_interval("120"), 120)
+
+
 class CsrfTokenExtractionTestCase(unittest.TestCase):
     """``_extract_submitted_token`` must always return a string so the
     ``secrets.compare_digest`` check in ``_csrf_before_request`` can never


### PR DESCRIPTION
## Summary

Two backend hardening fixes surfaced during the daily maintenance survey.

**1. Admin-triggered refreshes now update the upstream-API health card.**

`/admin/status` reads `PropertyService.get_cache_health()`, which reports `last_attempt_ok` / `last_success_at` / `last_error` / `last_refresh_seconds`. Those fields were only written by `refresh_cache` (the `/for-rent` and `/for-rent.json` path). `_refresh_with_change_log` — the worker fired by every `property_created` / `property_updated` / `image_added` mutation — did the same upstream fanout but never touched them, so admin-triggered refreshes silently regressed the status card to *"never refreshed yet"* until the next public `/for-rent` hit.

The fix mirrors `refresh_cache`'s contract in `_refresh_with_change_log`:

- Record success (including the no-diff branch, since the fetch still reached upstream) *before* touching the local cache — otherwise a steady-state site with no property changes but frequent admin activity drifts the status toward "stale" purely because nothing changed.
- Record failure with the error string on fetch exceptions.
- Stamp `_last_refresh_seconds` in the `finally` alongside `_last_refresh_monotonic` so the "creeping toward the 29s API Gateway ceiling" check on `/admin/status` covers this path too.

**2. Malformed `CACHE_REFRESH_INTERVAL` no longer crashes startup.**

`config.py` parsed `CACHE_REFRESH_INTERVAL` with a bare `int(os.getenv(...))`, which raised `ValueError` inside the dataclass `default_factory` and refused to boot on any mistyped value (`CACHE_REFRESH_INTERVAL=sixty`). Routed through the existing `_int_env` helper — same fallback contract `TRUSTED_PROXY_COUNT` already uses (blank / non-numeric / negative all fall back to the default).

## Test plan

- [x] `python -m unittest discover` → 791 pass, 1 skipped (unchanged)
- [x] `ruff check .` → clean
- [x] New coverage:
  - `test_refresh_with_change_log_records_success_health`
  - `test_refresh_with_change_log_records_success_even_when_unchanged`
  - `test_refresh_with_change_log_records_failure_health`
  - `CacheRefreshIntervalConfigTestCase` (5 tests mirroring `TrustedProxyConfigTestCase`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfCT3FonYwbsKt56wugzx3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfCT3FonYwbsKt56wugzx3)_