### PR TITLE
Fix subtle day-boundary and clock-sample inconsistencies

### DIFF
--- a/somewheria_app/services/analytics.py
+++ b/somewheria_app/services/analytics.py
@@ -83,9 +83,16 @@ class AnalyticsTracker:
             self.errors[today] += 1
 
     def dashboard_data(self, property_count: int) -> tuple[dict, dict]:
-        today = datetime.date.today().isoformat()
+        # Snapshot the current date ONCE so ``today`` and the tail of ``days``
+        # are guaranteed to agree even if the process crosses midnight between
+        # the two reads. Calling ``date.today()`` twice would rarely — but
+        # observably — bucket ``metrics["site_visits"]`` under yesterday while
+        # the chart's rightmost column labels today, and the two views of the
+        # same request would silently disagree.
+        today_date = datetime.date.today()
+        today = today_date.isoformat()
         days = [
-            (datetime.date.today() - datetime.timedelta(days=offset)).isoformat()
+            (today_date - datetime.timedelta(days=offset)).isoformat()
             for offset in range(self.analytics_days - 1, -1, -1)
         ]
         # Snapshot under the lock so the dashboard sees a consistent view even

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -237,9 +237,15 @@ class PropertyService:
                 # upstream outage means queued followers should serve the
                 # existing cache via the route's UpstreamUnavailable
                 # fallback rather than each retry the dead endpoint in
-                # series.
-                self._last_refresh_monotonic = time.monotonic()
-                self._last_refresh_seconds = time.monotonic() - started
+                # series. Take a single monotonic reading so the recorded
+                # completion timestamp and duration derive from the same
+                # clock sample — otherwise the follower coalesce check
+                # (``time.monotonic() - _last_refresh_monotonic``) and the
+                # admin-status duration would be computed from monotonic
+                # values a few operations apart.
+                completed_at = time.monotonic()
+                self._last_refresh_monotonic = completed_at
+                self._last_refresh_seconds = completed_at - started
 
     def get_cached_properties(self) -> list[dict]:
         with self.cache_lock:
@@ -399,9 +405,12 @@ class PropertyService:
                     # re-hit the same dead endpoint — mirrors the refresh_cache
                     # contract. Also stamp the observed fanout duration so
                     # the admin status page's "creeping toward 29s" check
-                    # covers both refresh paths.
-                    self._last_refresh_monotonic = time.monotonic()
-                    self._last_refresh_seconds = time.monotonic() - started
+                    # covers both refresh paths. Take a single monotonic
+                    # reading so the completion timestamp and duration
+                    # come from the same clock sample.
+                    completed_at = time.monotonic()
+                    self._last_refresh_monotonic = completed_at
+                    self._last_refresh_seconds = completed_at - started
         except Exception as exc:
             self.logger.error("On-demand refresh failed: %s", exc)
         finally:

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -522,6 +522,54 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertIn("upstream 502", health["last_error"])
         self.assertIsNotNone(health["last_refresh_seconds"])
 
+    def test_refresh_cache_records_consistent_timestamps(self):
+        # ``_last_refresh_monotonic`` and ``_last_refresh_seconds`` are both
+        # written in the ``finally`` block. The old code called
+        # ``time.monotonic()`` twice, so the "when did we finish?" timestamp
+        # and the "how long did it take?" duration derived from two different
+        # clock samples — a subtle inconsistency for the follower-coalesce
+        # comparison and the admin-status "creeping toward 29s" check. Pin the
+        # invariant: the recorded end-time must equal start-time plus duration.
+        # Sequence: [coalesce-check, started, completed].
+        coalesce_check_at = 100.0
+        started_at = 100.5
+        finished_at = 106.0
+        with patch.object(
+            self.service, "fetch_all_properties", return_value=[]
+        ), patch(
+            "somewheria_app.services.properties.time.monotonic",
+            side_effect=[coalesce_check_at, started_at, finished_at],
+        ):
+            self.service.refresh_cache()
+
+        self.assertEqual(self.service._last_refresh_monotonic, finished_at)
+        self.assertEqual(
+            self.service._last_refresh_seconds, finished_at - started_at
+        )
+
+    def test_refresh_with_change_log_records_consistent_timestamps(self):
+        # Same invariant as refresh_cache but for the admin-triggered path,
+        # which had the same duplicate-monotonic pattern in its finally.
+        # Sequence: [coalesce-check, started, completed].
+        coalesce_check_at = 200.0
+        started_at = 200.25
+        finished_at = 208.5
+        self.service.cache = [{"id": "prop-1", "name": "Old"}]
+        with patch.object(
+            self.service,
+            "fetch_all_properties",
+            return_value=[{"id": "prop-1", "name": "New"}],
+        ), patch(
+            "somewheria_app.services.properties.time.monotonic",
+            side_effect=[coalesce_check_at, started_at, finished_at],
+        ):
+            self.service._refresh_with_change_log("admin@example.com")
+
+        self.assertEqual(self.service._last_refresh_monotonic, finished_at)
+        self.assertEqual(
+            self.service._last_refresh_seconds, finished_at - started_at
+        )
+
     def test_fetch_all_properties_preserves_cache_when_every_record_fetch_fails(self):
         # IDs listing succeeds, but every per-property details fetch fails
         # (transient 5xx on the details endpoint). Without the guard,

--- a/test_services.py
+++ b/test_services.py
@@ -1228,6 +1228,54 @@ class AnalyticsPruningTestCase(unittest.TestCase):
         self.assertEqual(len(tracker.errors), 0)
 
 
+class DashboardDataDayBoundaryTestCase(unittest.TestCase):
+    """`dashboard_data` reads the current date once. The old code called
+    ``date.today()`` for ``today`` and then again inside the ``days`` list
+    comprehension; a request that happened to straddle midnight between those
+    two reads had ``metrics["site_visits"]`` bucketed under yesterday while
+    the chart's rightmost day labeled today, so the same request rendered
+    inconsistent numbers for the metric card and the chart."""
+
+    def test_today_matches_last_day_across_midnight(self):
+        import somewheria_app.services.analytics as analytics_module
+        from somewheria_app.services.analytics import AnalyticsTracker
+
+        real_datetime_module = analytics_module.datetime
+        # Advance the "clock" by one day on the second read. Under the old
+        # implementation the metrics bucket read the day-1 value while the
+        # chart's rightmost label was day-2 — visibly inconsistent.
+        returned = [
+            real_datetime_module.date(2026, 7, 4),
+            real_datetime_module.date(2026, 7, 5),
+        ]
+
+        class _AdvancingDate(real_datetime_module.date):
+            @classmethod
+            def today(cls):
+                return returned.pop(0) if returned else real_datetime_module.date(2026, 7, 5)
+
+        tracker = AnalyticsTracker(analytics_days=3)
+        # Seed both possible "today" buckets so we can prove which one won.
+        tracker.site_visits["2026-07-04"] = 42
+        tracker.site_visits["2026-07-05"] = 7
+
+        fake_module = SimpleNamespace(
+            date=_AdvancingDate,
+            datetime=real_datetime_module.datetime,
+            timedelta=real_datetime_module.timedelta,
+            timezone=real_datetime_module.timezone,
+        )
+        with patch.object(analytics_module, "datetime", fake_module):
+            metrics, chart_data = tracker.dashboard_data(property_count=0)
+
+        # ``today`` was read exactly once — so ``days[-1]`` and the bucket the
+        # ``site_visits`` metric read from must agree. Without the fix the
+        # metric would be 7 (from the second ``date.today()`` call) while the
+        # chart's last label would still read "2026-07-04" — or vice versa.
+        self.assertEqual(chart_data["days"][-1], "2026-07-04")
+        self.assertEqual(metrics["site_visits"], 42)
+
+
 class RecentListingActivityTestCase(unittest.TestCase):
     """`recent_listing_activity` buckets entries by the UTC ``YYYY-MM`` prefix
     of the change-log timestamp (`utcnow_iso()` writes Z-suffixed UTC). Labels


### PR DESCRIPTION
## Summary

Two small, focused correctness fixes for latent races between paired reads of the wall clock and the monotonic clock.

**`AnalyticsTracker.dashboard_data`** called `datetime.date.today()` twice — once for `today` and again inside the `days` list comprehension. A process that happened to cross midnight between those reads rendered `metrics["site_visits"]` under yesterday while the chart's rightmost column labeled today, so the metric card and the chart on the same page disagreed about which day was "now." Now reads the date once and derives both values from it.

**`PropertyService.refresh_cache` and `_refresh_with_change_log`** called `time.monotonic()` twice in their `finally` blocks — once for `_last_refresh_monotonic` (the "when did we finish?" timestamp the follower-coalesce check reads) and again for `_last_refresh_seconds` (the duration the admin-status "creeping toward 29s" check reads). A few operations of drift between the two reads left the recorded end time and the recorded duration derived from different clock samples. Now takes one reading and derives both.

## Test plan

- [x] `python -m unittest` — 798 tests pass (was 795; +3 for the invariants below)
- [x] `ruff check .` — clean
- [x] New: `DashboardDataDayBoundaryTestCase.test_today_matches_last_day_across_midnight` — mocks `date.today()` to return two different values across the two old call sites; asserts `chart_data["days"][-1]` and the bucket key used for `metrics["site_visits"]` agree.
- [x] New: `test_refresh_cache_records_consistent_timestamps` and `test_refresh_with_change_log_records_consistent_timestamps` — mock `time.monotonic()` with a deterministic sequence and assert `_last_refresh_monotonic == started + _last_refresh_seconds`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GqvR9gC1CoGDgdGCJHLJR6)_