### PR TITLE
Skip the pre-write deep-copy of the property cache during change-log diff

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -385,11 +385,15 @@ class PropertyService:
                         if self.cache == latest_properties:
                             self.logger.info("Refresh completed with no property changes")
                             return
-                        # Snapshot the pre-write cache for the change-log diff.
-                        # Deep-copied so ``_build_change_log`` doesn't see the
-                        # post-assignment cache state via aliasing.
-                        current_snapshot = copy.deepcopy(self.cache)
-                        log_details = self._build_change_log(current_snapshot, latest_properties)
+                        # Build the diff BEFORE reassigning ``self.cache``.
+                        # ``_build_change_log`` only reads ids/keys/values from
+                        # its inputs (never mutates them), so passing the live
+                        # cache list directly is safe and avoids deep-copying
+                        # tens of MB of base64 photo data on every admin
+                        # refresh. Same class of fix as commit 29e7f87 (drop
+                        # the JSON re-serialize) and cc20983 (drop the
+                        # deep-copy in property_count).
+                        log_details = self._build_change_log(self.cache, latest_properties)
                         self.cache = latest_properties
                     self.notifications.log_site_change(actor_email, "properties_cache_updated", log_details)
                     self.logger.info(

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import importlib
 import io
 import os
@@ -391,6 +392,32 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(change_log["old_count"], 2)
         self.assertEqual(change_log["new_count"], 2)
         self.assertEqual(change_log["changed"][0]["id"], "prop-1")
+
+    def test_build_change_log_does_not_mutate_its_inputs(self):
+        # ``_refresh_with_change_log`` hands the live cache directly to
+        # ``_build_change_log`` (no defensive deep-copy) so it can avoid
+        # copying tens of MB of base64 photo data on every admin-triggered
+        # refresh. That optimization is only safe if the diff routine is
+        # strictly read-only on its inputs -- lock that contract in a test
+        # so a future change can't silently regress the assumption and
+        # corrupt the live cache mid-swap.
+        current = [
+            {"id": "prop-1", "name": "Old", "photos": ["data:image/jpeg;base64,AAA="]},
+            {"id": "prop-2", "rent": "1000"},
+        ]
+        latest = [
+            {"id": "prop-1", "name": "New", "photos": ["data:image/jpeg;base64,BBB="]},
+            {"id": "prop-3", "rent": "1200"},
+        ]
+        # Deep-copy so ``assertEqual`` compares against the pre-call shape
+        # even if the routine mutated something in place.
+        current_before = copy.deepcopy(current)
+        latest_before = copy.deepcopy(latest)
+
+        self.service._build_change_log(current, latest)
+
+        self.assertEqual(current, current_before)
+        self.assertEqual(latest, latest_before)
 
     def test_fetch_all_properties_filters_out_missing_records(self):
         with patch.object(self.service, "_fetch_property_ids", return_value=["prop-1", "prop-2"]), patch.object(


### PR DESCRIPTION
## Summary

`_refresh_with_change_log` (the admin-triggered / `for-rent-refresh.json` path) was deep-copying `self.cache` before handing it to `_build_change_log`. On a fully-populated cache that's tens of MB of base64 photo payload copied per refresh — for a routine that only reads ids and compares field values and never mutates the input.

The comment justifying the copy said it was to avoid "post-assignment cache state via aliasing," but the diff runs *before* `self.cache = latest_properties`, so there's no aliasing risk. This drops the `copy.deepcopy(self.cache)` and passes the live cache list directly.

Same class of overhead removed by:
- cc20983 — dropped the deep-copy in `property_count`
- 9f8b99e — dropped the deep-copy just to read one property's name
- 29e7f87 — dropped the JSON re-serialize used for equality comparison

## Changes

- `somewheria_app/services/properties.py`: `_refresh_with_change_log` now passes `self.cache` straight to `_build_change_log`. Comment rewritten to explain the invariant (read-only inputs) that makes this safe.
- `test_coverage_full.py`: new `test_build_change_log_does_not_mutate_its_inputs` locks the read-only contract so a future edit to `_build_change_log` that mutated its inputs would fail loudly instead of silently corrupting the live cache mid-swap.

## Test plan

- [x] `python -m unittest test_coverage_full test_services test_routes_expanded test_sql_storage test_generated_matrices test_site test_oauth test_backup_script test_startup test_jira_integration` — all green locally (799 tests total across the run pattern I used).
- [x] New test verifies `_build_change_log(current, latest)` leaves both inputs byte-identical.
- [x] Existing `test_refresh_with_change_log_*` tests still pass, covering the change-log emission, monotonic-timestamp stamping, coalesce serialization, and health-tracking paths through the modified branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_015aQruxBjJjvQefWYTGe6FH)_