### PR TITLE
Restore CI: extend SqlStorage test fixture to hidden_listings_file

### DIFF
--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -25,6 +25,13 @@ def _make_config(base: Path) -> SimpleNamespace:
         contracts_file=base / "renter_contracts.json",
         tickets_file=base / "tickets.json",
         lead_capture_file=base / "pending_lead_captures.json",
+        # ``SqlStorageService._path_key`` compares the incoming path against
+        # every configured storage file, including the hidden-listings JSON,
+        # so this attribute has to be present for the unknown-path shim tests
+        # to even reach their assertion. Adding a new storage bucket without
+        # extending this fixture broke CI on main; keep every file the shim
+        # references listed here.
+        hidden_listings_file=base / "hidden_listings.json",
         sqlite_file=base / "test.sqlite3",
     )
 
@@ -223,6 +230,45 @@ class BinaryFileTestCase(SqlStorageBaseTestCase):
 
     def test_delete_file_returns_false_when_absent(self):
         self.assertFalse(self.storage.delete_file(self.base / "ghost.bin"))
+
+
+class HiddenListingsTestCase(SqlStorageBaseTestCase):
+    """The hidden-listings bucket landed without SQL-backend tests. Cover the
+    round-trip, the toggle semantics, and the path-shim wiring so future
+    additions to ``_path_key`` can't regress the shim silently again."""
+
+    def test_set_listing_hidden_round_trip(self):
+        self.storage.set_listing_hidden("prop-1", True)
+        self.assertEqual(self.storage.get_hidden_listing_ids(), ["prop-1"])
+
+    def test_set_listing_hidden_is_idempotent(self):
+        self.storage.set_listing_hidden("prop-1", True)
+        self.storage.set_listing_hidden("prop-1", True)
+        self.assertEqual(self.storage.get_hidden_listing_ids(), ["prop-1"])
+
+    def test_set_listing_hidden_false_removes_row(self):
+        self.storage.set_listing_hidden("prop-1", True)
+        self.storage.set_listing_hidden("prop-1", False)
+        self.assertEqual(self.storage.get_hidden_listing_ids(), [])
+
+    def test_get_hidden_listing_ids_sorted(self):
+        for pid in ("c", "a", "b"):
+            self.storage.set_listing_hidden(pid, True)
+        self.assertEqual(self.storage.get_hidden_listing_ids(), ["a", "b", "c"])
+
+    def test_load_via_path_shim(self):
+        self.storage.set_listing_hidden("prop-1", True)
+        loaded = self.storage.load_json_file(self.config.hidden_listings_file, [])
+        self.assertEqual(loaded, ["prop-1"])
+
+    def test_save_via_path_shim_replaces_table(self):
+        self.storage.set_listing_hidden("stale", True)
+        self.storage.save_json_file(
+            self.config.hidden_listings_file, ["fresh-1", "fresh-2"]
+        )
+        self.assertEqual(
+            self.storage.get_hidden_listing_ids(), ["fresh-1", "fresh-2"]
+        )
 
 
 class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):


### PR DESCRIPTION
## Summary

CI has been red on `main` since commit `a8089d8` ("Ship QA fixes and site redesign"). That commit added a new `hidden_listings` storage bucket and taught `SqlStorageService._path_key` about it, but the parallel change to `test_sql_storage._make_config` was missed. Two tests in `PathShimUnknownPathTestCase` exercise `_path_key` with an unrecognised path — the shim reaches the (missing) `self.config.hidden_listings_file` attribute and raises `AttributeError` before it can return the "unknown → default" fallback under test.

Confirmed the same failure locally and in every CI run since a8089d8 (three latest runs on `main` all fail with the same two errors in `test_sql_storage.PathShimUnknownPathTestCase`).

## Changes

- Add `hidden_listings_file` to the `SimpleNamespace` fixture in `test_sql_storage._make_config` so `_path_key` can complete under an unknown-path lookup.
- Add `HiddenListingsTestCase` covering the previously-untested SQL backend surface for hidden listings: round-trip, idempotent set, remove-on-false, sorted read, and the `load_json_file` / `save_json_file` path-shim wiring. This is the class of coverage that would have caught the original break in review, and pins the SQL/File parity contract this test module exists to enforce.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 FLASK_ENV=development SECRET_KEY=ci-only python -m unittest test_sql_storage` — 32 tests pass (was 26 with 2 errors on main; +6 new tests, all green).
- [x] `DISABLE_BACKGROUND_THREADS=1 FLASK_ENV=development SECRET_KEY=ci-only python -m unittest discover` — full suite green, 842 tests passing (skipped=1).
- [x] `ruff check .` — clean.
- [ ] CI on this PR reports green for both the unit-test and ruff jobs.


---
_Generated by [Claude Code](https://claude.ai/code/session_012zawhHTenZxyixH4ArydpP)_