### PR TITLE
Fix SqlStorageService._path_key crash on config missing an attribute

### DIFF
--- a/somewheria_app/services/sql_storage.py
+++ b/somewheria_app/services/sql_storage.py
@@ -58,22 +58,27 @@ class SqlStorageService:
 
     # ---------------------------------------------------------------- helpers
 
+    # (config attribute name, routing key). ``getattr`` with a ``None``
+    # default means a config missing one of these attributes reports an
+    # unknown path (falls back to the caller's default / no-op) rather
+    # than raising AttributeError halfway through the check — matching
+    # the contract exercised by ``PathShimUnknownPathTestCase``.
+    _PATH_KEY_ATTRS = (
+        ("registration_file", "pending_registrations"),
+        ("user_roles_file", "user_roles"),
+        ("renter_profile_file", "renter_profiles"),
+        ("contracts_file", "renter_contracts"),
+        ("tickets_file", "tickets"),
+        ("lead_capture_file", "lead_captures"),
+        ("hidden_listings_file", "hidden_listings"),
+    )
+
     def _path_key(self, path: Path) -> str:
         path = Path(path)
-        if path == self.config.registration_file:
-            return "pending_registrations"
-        if path == self.config.user_roles_file:
-            return "user_roles"
-        if path == self.config.renter_profile_file:
-            return "renter_profiles"
-        if path == self.config.contracts_file:
-            return "renter_contracts"
-        if path == self.config.tickets_file:
-            return "tickets"
-        if path == self.config.lead_capture_file:
-            return "lead_captures"
-        if path == self.config.hidden_listings_file:
-            return "hidden_listings"
+        for attr, key in self._PATH_KEY_ATTRS:
+            configured = getattr(self.config, attr, None)
+            if configured is not None and path == configured:
+                return key
         return ""
 
     # ---------------- Generic JSON shim used by TicketService et al --------

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -236,6 +236,26 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # Must not raise; the warning is logged but the request flow continues.
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
 
+    def test_missing_config_attribute_is_treated_as_unknown_path(self):
+        # If a config forgets one of the known file attributes (e.g. an
+        # older AppConfig deployed against a newer sql_storage), the path
+        # shim must fall through to the "unknown path" branch rather than
+        # raising AttributeError halfway through the checks. That would
+        # abort load/save for every path — including the ones the config
+        # DID configure correctly. The stock ``_make_config`` doesn't set
+        # ``hidden_listings_file`` at all, so the shim already needs to
+        # tolerate the missing attribute; if it doesn't, an unknown-path
+        # load raises AttributeError instead of returning the default.
+        self.assertFalse(hasattr(self.config, "hidden_listings_file"))
+        self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
+        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+        # A path that IS configured must still route correctly.
+        self.storage.set_user_role("still-works@example.com", "renter")
+        self.assertEqual(
+            self.storage.get_user_roles(),
+            {"still-works@example.com": "renter"},
+        )
+
 
 class AtomicTestCase(SqlStorageBaseTestCase):
     """``atomic()`` must serialize route-level read-modify-write sequences.


### PR DESCRIPTION
## Summary

Fixes two failing tests on `main` (`test_sql_storage.PathShimUnknownPathTestCase.test_unknown_load_returns_default` and `test_unknown_save_is_a_no_op`) that surfaced a small robustness bug in the SQLite storage backend.

## The bug

`SqlStorageService._path_key()` checked each candidate path via direct attribute lookup:

```python
if path == self.config.hidden_listings_file:
    return "hidden_listings"
```

If the config was missing any one of the referenced attributes, `getattr` raised `AttributeError` halfway through the checks — so `load_json_file`/`save_json_file` crashed for **every** path, including the ones the config DID configure correctly. The contract the surrounding tests describe ("unrecognised path must NOT silently corrupt or crash") was quietly broken.

The stock `SimpleNamespace` mock used across `test_sql_storage.py` intentionally omits `hidden_listings_file`, which is why the unknown-path guard tests were failing on `main`.

## The fix

- Iterate a `(attr_name, routing_key)` tuple table with `getattr(self.config, attr, None)` so an absent attribute is treated as "path not configured" rather than a crash. Table also makes future additions a one-line change.
- Add a regression test that pins the behaviour: with `hidden_listings_file` absent, an unknown path must still return default / no-op, and a still-configured path must still route correctly.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest test_sql_storage` — 27 tests, all pass (was 26 with 2 errors).
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 837 tests, all pass (was 836 with 2 errors).
- [x] No behavioural change for the real `AppConfig`, which sets every attribute the shim looks up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJxdA727DPwVGtLFdYsg74)_