### PR TITLE
Bound analytics visitor prune and safe backup retention env parsing

### DIFF
--- a/scripts/backup_database.py
+++ b/scripts/backup_database.py
@@ -125,6 +125,25 @@ def prune_local(dest_dir: Path, retention_days: int) -> int:
     return pruned
 
 
+def _int_env(name: str, default: int) -> int:
+    """Parse an integer env var with a safe fallback.
+
+    ``int(os.getenv(...))`` would raise ``ValueError`` on a mistyped value
+    like ``BACKUP_RETENTION_DAYS=weekly``, which happens AFTER a successful
+    S3 upload — the whole run then reports a non-zero exit to cron even
+    though the artifact is safely stored. Fall back to ``default`` for
+    blank / non-numeric / negative values instead.
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -165,7 +184,7 @@ def main(argv: list[str] | None = None) -> int:
         reason = "no BACKUP_S3_BUCKET" if not bucket else "AWS credentials not set"
         print(f"Skipping S3 upload ({reason})")
 
-    retention = int(os.getenv("BACKUP_RETENTION_DAYS", "7"))
+    retention = _int_env("BACKUP_RETENTION_DAYS", 7)
     pruned = prune_local(args.staging_dir, retention)
     if pruned:
         cutoff_dt = datetime.now(timezone.utc) - timedelta(days=retention)

--- a/somewheria_app/services/analytics.py
+++ b/somewheria_app/services/analytics.py
@@ -43,6 +43,12 @@ VISIT_SESSION_GAP_SECONDS = 30 * 60
 # Cap on the visitor-recency map so a flood of one-off clients (scanners,
 # bots) can't grow it unbounded; stale entries are dropped once crossed.
 _LAST_SEEN_PRUNE_THRESHOLD = 5000
+# When the map is still oversized after dropping expired sessions, compact
+# it down to this size by evicting the oldest surviving entries. Keeps the
+# per-request cost O(1) amortized: a burst that leaves 5001 genuinely-fresh
+# visitors would otherwise trigger the full O(N) filter on every subsequent
+# request until at least one entry aged out of the 30-min session window.
+_LAST_SEEN_HARD_CAP = _LAST_SEEN_PRUNE_THRESHOLD // 2
 
 
 class AnalyticsTracker:
@@ -112,6 +118,21 @@ class AnalyticsTracker:
                     for key, seen in self._visitor_last_seen.items()
                     if now - seen < VISIT_SESSION_GAP_SECONDS
                 }
+                # If every visitor was still inside the session window the
+                # filter above dropped nothing. Under sustained load that
+                # would re-run this O(N) walk on every subsequent request
+                # until an entry finally ages out. Force-compact by keeping
+                # only the ``_LAST_SEEN_HARD_CAP`` most-recently-seen
+                # visitors — the evicted ones are the ones closest to the
+                # session boundary anyway, so a returning-visitor undercount
+                # is bounded to that small oldest tail.
+                if len(self._visitor_last_seen) > _LAST_SEEN_PRUNE_THRESHOLD:
+                    newest = sorted(
+                        self._visitor_last_seen.items(),
+                        key=lambda item: item[1],
+                        reverse=True,
+                    )[:_LAST_SEEN_HARD_CAP]
+                    self._visitor_last_seen = dict(newest)
             self.unique_users[today].add(visitor)
 
     def after_request(self, response):

--- a/test_backup_script.py
+++ b/test_backup_script.py
@@ -15,6 +15,7 @@ These tests verify:
 from __future__ import annotations
 
 import gzip
+import os
 import sqlite3
 import sys
 import tempfile
@@ -22,6 +23,7 @@ import threading
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
@@ -141,6 +143,32 @@ class BackupCompressTests(unittest.TestCase):
                 conn.close()
             # At least the original seed row should be present.
             self.assertGreaterEqual(count, 1)
+
+
+class BackupIntEnvTests(unittest.TestCase):
+    def test_int_env_uses_default_when_unset(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BACKUP_RETENTION_DAYS", None)
+            self.assertEqual(backup_database._int_env("BACKUP_RETENTION_DAYS", 7), 7)
+
+    def test_int_env_uses_default_when_blank(self):
+        with patch.dict(os.environ, {"BACKUP_RETENTION_DAYS": "   "}):
+            self.assertEqual(backup_database._int_env("BACKUP_RETENTION_DAYS", 7), 7)
+
+    def test_int_env_uses_default_on_non_numeric(self):
+        # Regression: a mistyped env value ("weekly") used to raise
+        # ValueError AFTER a successful S3 upload, turning the whole run
+        # into a non-zero exit for cron even though the artifact was safe.
+        with patch.dict(os.environ, {"BACKUP_RETENTION_DAYS": "weekly"}):
+            self.assertEqual(backup_database._int_env("BACKUP_RETENTION_DAYS", 7), 7)
+
+    def test_int_env_uses_default_on_negative(self):
+        with patch.dict(os.environ, {"BACKUP_RETENTION_DAYS": "-3"}):
+            self.assertEqual(backup_database._int_env("BACKUP_RETENTION_DAYS", 7), 7)
+
+    def test_int_env_reads_valid_positive(self):
+        with patch.dict(os.environ, {"BACKUP_RETENTION_DAYS": "14"}):
+            self.assertEqual(backup_database._int_env("BACKUP_RETENTION_DAYS", 7), 14)
 
 
 if __name__ == "__main__":

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -1491,6 +1491,53 @@ class CoverageAnalyticsAndFactoryTestCase(unittest.TestCase):
 
         self.assertEqual(sum(self.analytics.site_visits.values()), 1)
 
+    def test_visitor_last_seen_hard_caps_when_all_entries_are_fresh(self):
+        # Regression: when the visitor-recency map crosses the soft cap AND
+        # every entry is still inside the session window, the old prune
+        # rebuild kept every key and left the map above threshold, forcing
+        # the O(N) filter to re-run on every subsequent request. The hard
+        # cap trims to _LAST_SEEN_HARD_CAP once the filter can't reduce.
+        from somewheria_app.services.analytics import (
+            _LAST_SEEN_HARD_CAP,
+            _LAST_SEEN_PRUNE_THRESHOLD,
+        )
+
+        # Seed with (threshold + 1) fresh entries so the prune branch fires
+        # but the "drop expired" filter has nothing to remove. Keep the
+        # timestamps well inside VISIT_SESSION_GAP_SECONDS of ``now`` so
+        # none of them look expired to the filter.
+        base = 10_000.0
+        self.analytics._visitor_last_seen = {
+            f"visitor-{i}": base + (i * 0.01)
+            for i in range(_LAST_SEEN_PRUNE_THRESHOLD + 1)
+        }
+        # Total spread above is ~50s; ``now`` sits a hair beyond the last
+        # seeded entry so every seeded visitor is well inside the 30-min
+        # session window.
+        now_stub = base + (_LAST_SEEN_PRUNE_THRESHOLD * 0.01) + 1
+
+        with self.app.test_request_context(
+            "/hello", headers={"User-Agent": self.BROWSER_UA}
+        ):
+            from flask import session
+
+            session["user"] = {"email": "new-visitor@example.com"}
+            with patch(
+                "somewheria_app.services.analytics.time.monotonic",
+                return_value=now_stub,
+            ):
+                self.analytics.before_request()
+
+        self.assertLessEqual(
+            len(self.analytics._visitor_last_seen), _LAST_SEEN_PRUNE_THRESHOLD
+        )
+        self.assertEqual(
+            len(self.analytics._visitor_last_seen), _LAST_SEEN_HARD_CAP
+        )
+        # The newest visitor (this request) must survive the compaction so
+        # its next visit within the session window is still recognised.
+        self.assertIn("new-visitor@example.com", self.analytics._visitor_last_seen)
+
     def test_normalize_property_resets_non_list_photos(self):
         notifications = Mock()
         service = PropertyService(


### PR DESCRIPTION
## Summary

Two independent backend robustness fixes surfaced during a survey of the app services and support scripts, each with its own regression test.

### 1. `AnalyticsTracker._visitor_last_seen` — bounded pruning

`before_request` grows a `visitor -> last_seen_time` map used to distinguish returning-session visits from new ones. When the map crossed the 5000-entry soft cap, the rebuild filtered out only visitors older than `VISIT_SESSION_GAP_SECONDS` (30 min). If **every** visitor was still inside the session window the filter kept them all — the map stayed above threshold and the next request repeated the O(N) walk, indefinitely.

Fix (`somewheria_app/services/analytics.py`): if the expiry filter can't reduce the map below the threshold, hard-compact by keeping only the `_LAST_SEEN_HARD_CAP` (2500) most-recently-seen entries. The evicted visitors are the ones closest to the 30-min boundary anyway, so a returning-visitor undercount is bounded to that oldest tail. Amortized cost is O(1) per request.

Regression test in `test_coverage_full.py` seeds `threshold + 1` genuinely-fresh entries and asserts the map is trimmed to `_LAST_SEEN_HARD_CAP` (and that the current request's visitor survives the compaction).

### 2. `scripts/backup_database.py` — safe `BACKUP_RETENTION_DAYS` parsing

`int(os.getenv("BACKUP_RETENTION_DAYS", "7"))` runs **after** the S3 upload, so a mistyped value like `BACKUP_RETENTION_DAYS=weekly` raised `ValueError` and turned an otherwise-successful backup into a non-zero cron exit even though the artifact was safely uploaded.

Fix: route through a local `_int_env` helper matching the contract used in `AppConfig._int_env` — blank / non-numeric / negative values fall back to the default rather than crashing.

Regression tests in `test_backup_script.py` cover unset, blank, non-numeric, negative, and valid inputs.

## Test plan

- [x] `python -m unittest discover` — 843 tests pass locally (up from 837 with 6 new tests).
- [ ] CI (GitHub Actions) green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V6c9dfEV5zubZqZQj8uA9P)_