### PR TITLE
Recompute contract status_class instead of trusting a persisted stale copy

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -240,9 +240,6 @@ def _backfill_contract_ids(services, contracts_for_email: list[dict], email: str
             contract["id"] = uuid_lib.uuid4().hex
             needs_save = True
         contract.setdefault("pdf_filename", "")
-        # Annotate a normalized status for templates without mutating the
-        # canonical free-form ``status`` field admins set in the form.
-        contract["status_class"] = _classify_contract_status(contract)
     if needs_save:
         # Hold the storage lock across load+modify+save so a concurrent
         # admin add/delete on the same renter can't race the backfill and
@@ -255,6 +252,13 @@ def _backfill_contract_ids(services, contracts_for_email: list[dict], email: str
                 services.storage.save_renter_contracts(all_contracts)
         except Exception:
             pass
+    # Compute the display class AFTER the save so it never lands on disk.
+    # It's a derived value that depends on today's date — persisting it lets
+    # a "pending" contract keep rendering as pending long after its
+    # start_date has passed, since ``contract_detail`` previously used
+    # ``setdefault`` and would not overwrite a stored stale value.
+    for contract in contracts_for_email:
+        contract["status_class"] = _classify_contract_status(contract)
     return contracts_for_email
 
 
@@ -945,7 +949,10 @@ def contract_detail(contract_id: str):
         contract, _ = _find_contract_for_email(services, email, contract_id)
     if not contract:
         return render_template("404.html", title="Contract Not Found"), 404
-    contract.setdefault("status_class", _classify_contract_status(contract))
+    # Always recompute — the JSON on disk may carry a stale ``status_class``
+    # persisted by an older backfill, and ``setdefault`` would keep the
+    # stale value instead of refreshing it against today's date.
+    contract["status_class"] = _classify_contract_status(contract)
     return render_template(
         "contract_detail.html",
         contract=contract,

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -1730,6 +1730,85 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
             response = self.client.get("/contracts/contract-xyz")
         self.assertEqual(response.status_code, 404)
 
+    def test_backfill_contract_ids_does_not_persist_status_class(self):
+        """``status_class`` is derived from today's date and the contract's
+        start/end dates, so persisting it lets a "pending" contract keep
+        rendering as pending long after start_date has passed. The backfill
+        must add ids to disk without leaking the derived field.
+        """
+        from somewheria_app.routes.admin_routes import _backfill_contract_ids
+
+        # Contracts missing ``id`` — triggers the backfill save.
+        contracts = [
+            {
+                "property_name": "Maple House",
+                "start_date": "2024-01-01",
+                "end_date": "2025-01-01",
+                "status": "unrecognized-freeform",
+            }
+        ]
+        # Snapshot the payload AT SAVE TIME (deep copy) because the function
+        # mutates the same dict in place after the save call to attach the
+        # derived ``status_class`` — a plain Mock only records references.
+        saved_snapshots: list[dict] = []
+
+        def _snapshot_save(payload):
+            saved_snapshots.append(copy.deepcopy(payload))
+
+        with patch.object(
+            self.services.storage, "get_renter_contracts", return_value={"renter@example.com": contracts}
+        ), patch.object(
+            self.services.storage, "save_renter_contracts", side_effect=_snapshot_save
+        ):
+            _backfill_contract_ids(self.services, contracts, "renter@example.com")
+
+        self.assertEqual(len(saved_snapshots), 1)
+        saved_payload = saved_snapshots[0]
+        for saved_contract in saved_payload["renter@example.com"]:
+            self.assertNotIn(
+                "status_class",
+                saved_contract,
+                "status_class is derived from today's date; persisting it stales the badge",
+            )
+            self.assertIn("id", saved_contract, "id should have been backfilled")
+        # In-memory, the returned contracts still carry the derived field
+        # so callers (dashboard render) can use it without an extra call.
+        self.assertIn("status_class", contracts[0])
+
+    def test_contract_detail_recomputes_stale_status_class(self):
+        """A ``status_class`` persisted by an earlier backfill (before the
+        fix) can become stale as dates advance; the detail route must
+        recompute it rather than trust the stored value.
+        """
+        self.login_as("renter", email="renter@example.com")
+        # start_date is in the past — the fresh classification is "active".
+        # The persisted value is deliberately stale ("pending"), matching
+        # what a pre-fix backfill would have written to disk.
+        yesterday = (datetime.date.today() - datetime.timedelta(days=30)).isoformat()
+        future = (datetime.date.today() + datetime.timedelta(days=365)).isoformat()
+        contracts_data = {
+            "renter@example.com": [
+                {
+                    "id": "stale-status",
+                    "property_name": "Maple House",
+                    "start_date": yesterday,
+                    "end_date": future,
+                    "status": "unrecognized-freeform",
+                    "status_class": "pending",  # stale, persisted from before the fix
+                    "pdf_filename": "",
+                }
+            ]
+        }
+        with patch.object(
+            self.services.storage, "get_renter_contracts", return_value=contracts_data
+        ):
+            response = self.client.get("/contracts/stale-status")
+        self.assertEqual(response.status_code, 200)
+        # The active badge picks up ``sw-badge-ok``; a stale pending would
+        # render ``sw-badge-warn`` per the template's mapping.
+        self.assertIn(b"sw-badge-ok", response.data)
+        self.assertNotIn(b"sw-badge-warn", response.data)
+
     def test_contract_download_serves_pdf(self):
         self.login_as("renter", email="renter@example.com")
         contract_id = "contract-dl"


### PR DESCRIPTION
## Summary

Fixes a subtle staleness bug where the contract-status badge (`active` /
`pending` / `ended`) on the renter dashboard and contract-detail page can
freeze at whatever classification was current the day a contract's id
was first backfilled.

### Root cause

`_backfill_contract_ids` in `somewheria_app/routes/admin_routes.py` was
assigning the derived `status_class` to every contract before saving.
Once the id backfill triggered a `save_renter_contracts` (any renter with
at least one legacy contract lacking an `id`), that derived value landed
on disk. Later, `contract_detail` used
`contract.setdefault("status_class", _classify_contract_status(contract))`,
which keeps the stored value rather than recomputing it — so a
"pending" classification stayed frozen long after `start_date` had
passed.

The bug only manifested for contracts whose free-form `status` string
didn't match a recognized word (`active` / `pending` / `ended` /
`current` / `upcoming` / `draft` / `expired` / `terminated` / `closed`)
— those cases fall through to date-driven inference, so the correct
badge changes over time.

### Fix

- `_backfill_contract_ids`: compute `status_class` **after** the save,
  so the derived value never lands on disk.
- `contract_detail`: `contract["status_class"] = _classify_contract_status(contract)`
  (assign, don't setdefault), so a stale value from a pre-fix backfill
  is always refreshed against today's date.

### Tests

Two regression tests in `test_routes_expanded.py`:

- `test_backfill_contract_ids_does_not_persist_status_class` — snapshots
  the save payload and asserts `status_class` is absent from every
  saved contract while `id` is still backfilled and the in-memory
  return value carries the derived field.
- `test_contract_detail_recomputes_stale_status_class` — seeds a
  contract whose stored `status_class` is `"pending"` but whose actual
  start_date is 30 days in the past; verifies the rendered page picks
  up `sw-badge-ok` (active) and never renders `sw-badge-warn` (stale
  pending).

Full test suite: **839 tests, all passing**.

## Test plan

- [x] `python -m unittest discover` — 839 pass, 1 skipped, 0 failures
- [x] New tests exercise both the write path (backfill) and the read
      path (contract_detail) so a regression in either half is caught.
- [x] No changes to any HTML template or public JS — backend-only fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELtpw2fF64Wgu5DoSKe6QC)_