### PR TITLE
Honour DISABLE_BACKGROUND_THREADS in ZillowPublisher._enqueue

### DIFF
--- a/somewheria_app/services/zillow.py
+++ b/somewheria_app/services/zillow.py
@@ -121,6 +121,30 @@ class ZillowPublisher:
             )
             return
 
+        # Honour the DISABLE_BACKGROUND_THREADS hatch used by the JIRA mirror
+        # and the rest of the app so test runs stay synchronous and
+        # predictable. Run a single publish attempt inline (no retries, no
+        # backoff sleeps) — tests exercising the retry ladder itself already
+        # call _retry_worker directly with time.sleep patched out.
+        if os.getenv("DISABLE_BACKGROUND_THREADS") == "1":
+            try:
+                self._perform_publish(action, property_id, payload)
+                self._record_success(action, property_id)
+            except Exception as exc:
+                self._record_failure(action, property_id, str(exc))
+                try:
+                    self.notifications.log_and_notify_error(
+                        "Zillow Sync Failure",
+                        f"Zillow publish failed inline. action={action} "
+                        f"property_id={property_id} error={exc}",
+                    )
+                except Exception as notify_exc:
+                    self.logger.error(
+                        "Could not notify admin of Zillow failure: %s",
+                        notify_exc,
+                    )
+            return
+
         worker = threading.Thread(
             target=self._retry_worker,
             args=(action, property_id, payload),

--- a/test_services.py
+++ b/test_services.py
@@ -2022,6 +2022,74 @@ class ZillowPublisherTestCase(unittest.TestCase):
         self.assertIn("failure_count", snapshot)
         self.assertIn("recent_errors", snapshot)
 
+    def test_publish_runs_inline_when_background_threads_disabled(self):
+        # DISABLE_BACKGROUND_THREADS=1 mirrors the JIRA mirror's hatch:
+        # publishes execute inline (no daemon thread, no backoff sleeps) so
+        # tests stay deterministic and side effects are observable the
+        # moment the call returns. Without this a routing test that
+        # exercises a create/update/delete path with Zillow creds present
+        # spawns a thread that outlives the test and races teardown.
+        with patch.dict(
+            "os.environ",
+            {
+                "ZILLOW_API_BASE_URL": "https://zillow.example.com",
+                "ZILLOW_API_TOKEN": "token",
+                "ZILLOW_FEED_KEY": "feed",
+                "DISABLE_BACKGROUND_THREADS": "1",
+            },
+        ), patch.object(self.publisher, "_perform_publish") as perform:
+            self.publisher.publish_create({"id": "prop-1"})
+            perform.assert_called_once_with("create", "prop-1", {"property": {"id": "prop-1"}})
+        # Success recorded synchronously — no thread involved.
+        self.assertEqual(self.publisher.success_count, 1)
+        self.assertEqual(self.publisher.failure_count, 0)
+
+    def test_inline_publish_records_failure_and_notifies_on_error(self):
+        # Same hatch, but the (stubbed) publish raises. The inline path must
+        # still record the failure on the status snapshot and route the
+        # admin alert through NotificationService — matching the async
+        # path's contract so an operator sees the outage either way.
+        with patch.dict(
+            "os.environ",
+            {
+                "ZILLOW_API_BASE_URL": "https://zillow.example.com",
+                "ZILLOW_API_TOKEN": "token",
+                "ZILLOW_FEED_KEY": "feed",
+                "DISABLE_BACKGROUND_THREADS": "1",
+            },
+        ), patch.object(
+            self.publisher, "_perform_publish", side_effect=RuntimeError("boom")
+        ):
+            self.publisher.publish_update({"id": "prop-2"})
+        self.assertEqual(self.publisher.failure_count, 1)
+        self.assertEqual(self.publisher.success_count, 0)
+        self.notifications.log_and_notify_error.assert_called_once()
+        # The recent-errors ring buffer captured the failure for the
+        # admin-status page.
+        snapshot = self.publisher.status_snapshot()
+        self.assertEqual(len(snapshot["recent_errors"]), 1)
+        self.assertEqual(snapshot["recent_errors"][0]["action"], "update")
+        self.assertEqual(snapshot["recent_errors"][0]["property_id"], "prop-2")
+
+    def test_inline_publish_skipped_when_credentials_missing(self):
+        # Even with the DISABLE_BACKGROUND_THREADS hatch on, missing
+        # credentials must short-circuit before touching _perform_publish —
+        # otherwise a partially-configured environment would fabricate
+        # "success" for a call that was never made.
+        with patch.dict(
+            "os.environ",
+            {
+                "ZILLOW_API_BASE_URL": "",
+                "ZILLOW_API_TOKEN": "",
+                "ZILLOW_FEED_KEY": "",
+                "DISABLE_BACKGROUND_THREADS": "1",
+            },
+        ), patch.object(self.publisher, "_perform_publish") as perform:
+            self.publisher.publish_delete("prop-3")
+            perform.assert_not_called()
+        self.assertEqual(self.publisher.success_count, 0)
+        self.assertEqual(self.publisher.failure_count, 0)
+
 
 class TicketsNowIsoTestCase(unittest.TestCase):
     """Lock the on-disk timestamp format for tickets.


### PR DESCRIPTION
## Summary

`ZillowPublisher._enqueue` unconditionally spawned a daemon retry worker
whenever Zillow credentials were configured. Every other background path
in the app (JIRA mirror creation, on-demand cache refresh) already
short-circuits onto inline execution when `DISABLE_BACKGROUND_THREADS=1`
so test runs stay synchronous and threads don't outlive teardown — the
Zillow path was the outlier.

Under the hatch we now run a single publish attempt inline (no retries,
no backoff sleeps) and route success/failure through the same
`_record_success` / `_record_failure` / admin-email paths the async
worker uses, so the admin-status snapshot and the "Zillow Sync Failure"
notification stay consistent between the two modes. The retry-ladder
test keeps calling `_retry_worker` directly with `time.sleep` patched
out — that behaviour is untouched.

## Changes

- `somewheria_app/services/zillow.py`: check `DISABLE_BACKGROUND_THREADS`
  in `_enqueue`; when set, run `_perform_publish` inline and record
  success/failure + notify on error. Credentials-missing short-circuit is
  preserved (no spurious "success" for a call that was never made).
- `test_services.py`: three new `ZillowPublisherTestCase` cases
  covering the inline success path, the inline failure path (verifies
  `failure_count`, notification, and the `recent_errors` ring buffer),
  and the credentials-missing short-circuit under the hatch.

## Test plan

- [x] `python -m unittest discover` (840 tests, all pass, +3 vs. main)
- [x] `python -m unittest test_services.ZillowPublisherTestCase -v`
      (8/8 pass; retry-ladder test still exercises `_retry_worker`
      directly with patched sleep, unchanged behaviour)


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qm12GNUk72MboxqTvcfBN)_