### PR TITLE
Downgrade AppointmentService.load() INFO logs to DEBUG

### DIFF
--- a/somewheria_app/services/appointments.py
+++ b/somewheria_app/services/appointments.py
@@ -21,14 +21,19 @@ class AppointmentService:
         self.logger.info("%s: %s (%s)", purpose, abs_path, status)
 
     def load(self) -> dict[str, set[str]]:
+        # ``property_details`` calls this on every page view (including bot
+        # crawlers), so keep it at DEBUG — routine reads at INFO fill the
+        # 10 MB rotating application.log with duplicate lines and shorten
+        # the useful log retention window. Mutations (save/book) still log
+        # at INFO because they're rare and worth the audit trail.
         appointments: dict[str, set[str]] = {}
-        abs_path = self.config.property_appointments_file.resolve()
-        self.logger.info("Loading appointments from %s", abs_path)
-        if not self.config.property_appointments_file.exists():
-            self.logger.info("Appointments file does not exist yet: %s", abs_path)
+        path = self.config.property_appointments_file
+        if not path.exists():
+            self.logger.debug("Appointments file does not exist yet: %s", path)
             return appointments
+        self.logger.debug("Loading appointments from %s", path)
         with self._lock:
-            with self.config.property_appointments_file.open("r", encoding="utf-8") as handle:
+            with path.open("r", encoding="utf-8") as handle:
                 for raw_line in handle:
                     line = raw_line.strip()
                     if not line:

--- a/test_services.py
+++ b/test_services.py
@@ -540,6 +540,21 @@ class AppointmentServiceTestCase(unittest.TestCase):
         self.assertEqual(loaded["prop-1"], {"2030-05-01", "2030-05-02"})
         self.assertEqual(loaded["prop-2"], {"2030-05-01"})
 
+    def test_load_does_not_emit_info_logs(self):
+        # Regression: /property/<uuid> calls load() on every page view,
+        # including bot crawlers. Emitting INFO logs on each read fills
+        # the rotating application.log with duplicate lines and shortens
+        # the useful log retention window. Routine reads must stay at
+        # DEBUG so INFO retains signal for mutations and errors.
+        self.service.save({"prop-1": {"2030-05-01"}})
+        with patch.object(self.service.logger, "info") as info_mock:
+            self.service.load()
+            # Also cover the missing-file branch, which had its own INFO
+            # line.
+            self.appointments_path.unlink()
+            self.service.load()
+        info_mock.assert_not_called()
+
 
 class PropertyServiceTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

`property_details()` calls `AppointmentService.load()` on every page view — including bot crawlers. At INFO level the routine read emitted two lines per hit ("Loading appointments from …" and, before the first booking, "Appointments file does not exist yet: …"), which fills the 10 MB rotating `application.log` with duplicate noise and shortens the useful retention window.

## Changes

- `services/appointments.py`: downgrade both read log lines in `load()` from INFO to DEBUG so routine reads no longer pollute `application.log`. Mutations (`save`/`book`) keep their INFO lines because they're rare and worth the audit trail.
- Drop the eager `.resolve()` on every load (only used for logging; canonicalizing the path is a syscall) and lazily format the still-DEBUG lines through standard logging %-formatting so nothing is computed unless DEBUG is enabled.
- `test_services.py`: add `test_load_does_not_emit_info_logs` covering both the file-present and file-missing branches so a future accidental re-upgrade is caught.

## Test plan

- [x] `python -m unittest test_services.AppointmentServiceTestCase -v` — all 9 tests pass, including the new regression.
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — full suite (838 tests) passes.
- [x] Manual sanity: 10 `load()` calls now emit 0 INFO lines (previously 10); `save()` still emits its 2 informative INFO lines unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqDwQ4ptjr93mTRzmzGvUc)_