### PR TITLE
Quiet AppointmentService's per-request log noise

### DIFF
--- a/somewheria_app/services/appointments.py
+++ b/somewheria_app/services/appointments.py
@@ -21,32 +21,51 @@ class AppointmentService:
         self.logger.info("%s: %s (%s)", purpose, abs_path, status)
 
     def load(self) -> dict[str, set[str]]:
+        # Called on every /property/<uuid> page render, so the routine
+        # "loading ..." / "not created yet" traces sit at DEBUG — otherwise a
+        # single visit dominates application.log with no-signal messages.
+        # Startup / booking flows still get an INFO trail via
+        # print_check_file() and NotificationService.log_site_change().
         appointments: dict[str, set[str]] = {}
-        abs_path = self.config.property_appointments_file.resolve()
-        self.logger.info("Loading appointments from %s", abs_path)
-        if not self.config.property_appointments_file.exists():
-            self.logger.info("Appointments file does not exist yet: %s", abs_path)
-            return appointments
+        path = self.config.property_appointments_file
+        # Hold the lock across the existence check and open() so a concurrent
+        # save() (which creates the file atomically via os.replace) cannot
+        # create-then-be-observed-as-missing between the two calls. This is a
+        # thin race in practice — save() is rare — but keeps the read side
+        # observation consistent with the write side.
         with self._lock:
-            with self.config.property_appointments_file.open("r", encoding="utf-8") as handle:
+            if not path.exists():
+                self.logger.debug("Appointments file does not exist yet: %s", path.resolve())
+                return appointments
+            self.logger.debug("Loading appointments from %s", path.resolve())
+            with path.open("r", encoding="utf-8") as handle:
                 for raw_line in handle:
                     line = raw_line.strip()
                     if not line:
                         continue
                     try:
                         property_id, dates = line.split(":", 1)
-                        appointments[property_id.strip()] = {item for item in dates.split(",") if item}
-                    except Exception:
+                    except ValueError:
                         continue
+                    property_id = property_id.strip()
+                    # Skip lines that stored an empty property id — treating
+                    # them as real entries would pollute the returned map with
+                    # a bogus "" key that gets re-written on the next save().
+                    if not property_id:
+                        continue
+                    appointments[property_id] = {item for item in dates.split(",") if item}
         return appointments
 
     def save(self, appointments: dict[str, set[str]]) -> None:
         # Atomic write: render the full payload to a sibling temp file, fsync,
         # then os.replace() over the destination. A crash mid-write leaves the
         # original file intact instead of a half-written, truncated one.
+        #
+        # DEBUG log level: save() runs on every booking, and successful writes
+        # are already observable via os.replace() completing (and via the
+        # ``ticket_created`` / notification email fired by the caller).
         path = self.config.property_appointments_file
-        abs_path = path.resolve()
-        self.logger.info("Saving %s appointment sets to %s", len(appointments), abs_path)
+        self.logger.debug("Saving %s appointment sets to %s", len(appointments), path.resolve())
         with self._lock:
             path.parent.mkdir(parents=True, exist_ok=True)
             fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
@@ -64,7 +83,6 @@ class AppointmentService:
                 except OSError:
                     pass
                 raise
-        self.print_check_file(self.config.property_appointments_file, "Appointments saved")
 
     def book(self, property_id: str, iso_date: str) -> bool:
         # Returns True when the booking was newly recorded, False when the

--- a/test_services.py
+++ b/test_services.py
@@ -540,6 +540,45 @@ class AppointmentServiceTestCase(unittest.TestCase):
         self.assertEqual(loaded["prop-1"], {"2030-05-01", "2030-05-02"})
         self.assertEqual(loaded["prop-2"], {"2030-05-01"})
 
+    def test_load_skips_empty_property_id_line(self):
+        # A line stored with an empty property id (``:2030-01-10``) would
+        # otherwise land in the returned map under the "" key and get
+        # re-written verbatim by the next save(). Skip it silently so a
+        # hand-edited or corrupted file doesn't accumulate garbage entries.
+        self.appointments_path.write_text(
+            "prop-1:2030-01-10\n:2030-01-11\n",
+            encoding="utf-8",
+        )
+        loaded = self.service.load()
+        self.assertEqual(loaded, {"prop-1": {"2030-01-10"}})
+        self.assertNotIn("", loaded)
+
+    def test_load_does_not_log_at_info_on_every_call(self):
+        # load() is called on every /property/<uuid> page render; routine
+        # traces must sit at DEBUG so real-user traffic doesn't dominate
+        # application.log with no-signal messages. Regressions here would
+        # re-introduce the log flood this cleanup addressed.
+        self.appointments_path.write_text("prop-1:2030-01-10\n", encoding="utf-8")
+        with patch.object(self.service.logger, "info") as info_mock:
+            self.service.load()
+            # Also cover the "missing file" branch — same rationale.
+            self.appointments_path.unlink()
+            self.service.load()
+        info_mock.assert_not_called()
+
+    def test_save_does_not_log_at_info_or_call_print_check_file(self):
+        # save() is called from every booking; the successful path is
+        # observable via os.replace(), and log_site_change / the notification
+        # email in schedule_appointment already record the business event.
+        # An INFO trace here (and the redundant print_check_file() call the
+        # previous implementation made) is dead weight.
+        with patch.object(self.service.logger, "info") as info_mock, patch.object(
+            self.service, "print_check_file"
+        ) as print_check_mock:
+            self.service.save({"prop-1": {"2030-05-01"}})
+        info_mock.assert_not_called()
+        print_check_mock.assert_not_called()
+
 
 class PropertyServiceTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

`AppointmentService.load()` is called from `property_details` on every `/property/<uuid>` page render. Its routine "Loading appointments from ..." trace (and the "not created yet" branch) sat at INFO, so real-user + crawler traffic dominated `application.log` with no-signal messages. Same story for `save()` on every booking, plus a redundant `print_check_file()` call at the end of `save()` that re-checks the file we atomically wrote.

- Downgrade the per-request `load()` and per-booking `save()` traces to DEBUG. Successful writes are already observable via `os.replace()` completing and the notification email fired by the caller; startup diagnostics still get an INFO trail via `print_check_file()` called from `website_app.py`.
- Drop the trailing `print_check_file()` call inside `save()` — dead noise.
- Move the `.exists()` check in `load()` inside `self._lock` so a concurrent `save()` can't be observed as missing between the check and the open.
- Skip lines whose `property_id` is empty when loading, so a hand-edited or corrupted file doesn't accumulate a bogus `""` bucket that gets re-written on the next save.

## Test plan

- [x] `python -m unittest test_services.AppointmentServiceTestCase -v` — 11 tests pass (8 existing + 3 new: empty-id skipped, no INFO on routine load, no INFO / `print_check_file` on save)
- [x] Full suite: `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 840 tests OK (was 837)


---
_Generated by [Claude Code](https://claude.ai/code/session_013kf9twgGQ1Q7CQtceouiuh)_