### PR TITLE
Move ticket-email sends off the request thread; fix contract-backfill race

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -234,27 +234,38 @@ def _backfill_contract_ids(services, contracts_for_email: list[dict], email: str
     one in (and persist the back-fill) so renter links can target them."""
     if not contracts_for_email:
         return contracts_for_email
-    needs_save = False
-    for contract in contracts_for_email:
-        if not contract.get("id"):
-            contract["id"] = uuid_lib.uuid4().hex
-            needs_save = True
-        contract.setdefault("pdf_filename", "")
-        # Annotate a normalized status for templates without mutating the
-        # canonical free-form ``status`` field admins set in the form.
-        contract["status_class"] = _classify_contract_status(contract)
-    if needs_save:
-        # Hold the storage lock across load+modify+save so a concurrent
-        # admin add/delete on the same renter can't race the backfill and
-        # silently lose one side's write. Mirrors the lost-update fix in
-        # commit e062313 for tickets and pending registrations.
-        try:
-            with services.storage.atomic():
-                all_contracts = services.storage.get_renter_contracts()
+    needs_save = any(not contract.get("id") for contract in contracts_for_email)
+    if not needs_save:
+        for contract in contracts_for_email:
+            contract.setdefault("pdf_filename", "")
+            # Annotate a normalized status for templates without mutating the
+            # canonical free-form ``status`` field admins set in the form.
+            contract["status_class"] = _classify_contract_status(contract)
+        return contracts_for_email
+    # Hold the storage lock across load+modify+save so a concurrent
+    # admin add/delete on the same renter can't race the backfill and
+    # silently lose one side's write. Re-read the fresh list inside the
+    # lock (the caller's snapshot pre-dates any concurrent modification);
+    # writing back the stale snapshot would clobber those changes. Mirrors
+    # the lost-update fix in commit e062313 for tickets and pending
+    # registrations.
+    try:
+        with services.storage.atomic():
+            all_contracts = services.storage.get_renter_contracts()
+            contracts_for_email = all_contracts.get(email, [])
+            fresh_changed = False
+            for contract in contracts_for_email:
+                if not contract.get("id"):
+                    contract["id"] = uuid_lib.uuid4().hex
+                    fresh_changed = True
+            if fresh_changed:
                 all_contracts[email] = contracts_for_email
                 services.storage.save_renter_contracts(all_contracts)
-        except Exception:
-            pass
+    except Exception:
+        pass
+    for contract in contracts_for_email:
+        contract.setdefault("pdf_filename", "")
+        contract["status_class"] = _classify_contract_status(contract)
     return contracts_for_email
 
 

--- a/somewheria_app/services/tickets.py
+++ b/somewheria_app/services/tickets.py
@@ -200,22 +200,22 @@ class TicketService:
             tickets.append(ticket)
             self._save(tickets)
 
-        try:
-            # Notify the internal admin inbox.
-            self.notifications.send_email(
-                f"New Repair Ticket: {title}",
-                (
-                    f"Ticket ID: {ticket['id']}\n"
-                    f"Submitted by: {submitter_name or submitter_email or 'anonymous'}\n"
-                    f"Contact: {contact or '(none)'}\n"
-                    f"Property: {property_name or '(not specified)'}\n"
-                    f"Category: {category}\n"
-                    f"Priority: {priority}\n\n"
-                    f"{description}"
-                ),
-            )
-        except Exception as exc:  # notifications must not block ticket creation
-            self.logger.warning("Failed to send ticket email: %s", exc)
+        # Notify the internal admin inbox. Dispatched off the request thread
+        # so a slow/unreachable SMTP relay can't stall the caller for up to
+        # ``SMTP_TIMEOUT_SECONDS`` (30s) — matching how the JIRA mirror
+        # already runs in a daemon thread below.
+        self._enqueue_email(
+            f"New Repair Ticket: {title}",
+            (
+                f"Ticket ID: {ticket['id']}\n"
+                f"Submitted by: {submitter_name or submitter_email or 'anonymous'}\n"
+                f"Contact: {contact or '(none)'}\n"
+                f"Property: {property_name or '(not specified)'}\n"
+                f"Category: {category}\n"
+                f"Priority: {priority}\n\n"
+                f"{description}"
+            ),
+        )
 
         # Confirmation email to the renter so they know we got it.
         self._maybe_email_submitter(
@@ -250,6 +250,42 @@ class TicketService:
             self._enqueue_jira_create(ticket["id"])
 
         return ticket
+
+    # ------------------------------------------------------- email dispatch
+
+    def _enqueue_email(self, subject: str, body: str, to: str | None = None) -> None:
+        """Send an email off the request thread.
+
+        SMTP has a 30 s socket timeout, so a slow Gmail relay could otherwise
+        stall the caller by that much per send — a ticket-creation request
+        that fires an internal notice plus a submitter confirmation could
+        block for up to a minute. All email sends from this service are
+        fire-and-forget (callers don't rely on the return value; delivery
+        failures are already logged inside ``NotificationService.send_email``),
+        so dispatching from a daemon thread preserves semantics while
+        removing the latency from the request path.
+
+        Honours ``DISABLE_BACKGROUND_THREADS=1`` so test runs stay
+        synchronous and can assert against mocked ``send_email`` calls.
+        """
+        if os.getenv("DISABLE_BACKGROUND_THREADS") == "1":
+            try:
+                self.notifications.send_email(subject, body, to=to)
+            except Exception as exc:
+                self.logger.warning("Inline email send failed for %r: %s", subject, exc)
+            return
+
+        def _worker() -> None:
+            try:
+                self.notifications.send_email(subject, body, to=to)
+            except Exception as exc:
+                self.logger.warning("Background email send failed for %r: %s", subject, exc)
+
+        threading.Thread(
+            target=_worker,
+            name="ticket-email",
+            daemon=True,
+        ).start()
 
     # --------------------------------------------------------------- JIRA
 
@@ -356,10 +392,9 @@ class TicketService:
         recipient = (ticket.get("submitted_by") or "").strip()
         if not is_valid_email(recipient):
             return
-        try:
-            self.notifications.send_email(subject, body, to=recipient)
-        except Exception as exc:
-            self.logger.warning("Failed to email submitter for ticket %s: %s", ticket.get("id"), exc)
+        # Fire-and-forget: dispatched off the request thread so a slow SMTP
+        # relay can't stall the caller. See ``_enqueue_email``.
+        self._enqueue_email(subject, body, to=recipient)
 
     def update_ticket(
         self,
@@ -597,17 +632,15 @@ class TicketService:
         else:
             # Note from the submitter — notify the internal inbox so staff
             # see a renter reply even if they're not watching the dashboard.
-            try:
-                self.notifications.send_email(
-                    f"Renter note on ticket: {ticket.get('title', '')}",
-                    (
-                        f"Ticket: {ticket_id[:8]}\n"
-                        f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
-                        f"{text}"
-                    ),
-                )
-            except Exception as exc:
-                self.logger.warning("Failed to forward renter note: %s", exc)
+            # Dispatched off the request thread; see ``_enqueue_email``.
+            self._enqueue_email(
+                f"Renter note on ticket: {ticket.get('title', '')}",
+                (
+                    f"Ticket: {ticket_id[:8]}\n"
+                    f"From: {ticket.get('submitter_name') or submitter or 'renter'}\n\n"
+                    f"{text}"
+                ),
+            )
 
         try:
             self.notifications.log_site_change(

--- a/test_jira_integration.py
+++ b/test_jira_integration.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -156,6 +157,59 @@ class TicketServiceJiraWiringTestCase(unittest.TestCase):
         # Must not raise even though JIRA blows up.
         ticket = svc.create_ticket(
             {"title": "Heater", "description": "Cold"}, submitter_email="r@example.com"
+        )
+        self.assertIn("id", ticket)
+
+    def test_slow_smtp_does_not_block_ticket_creation(self):
+        # Simulate a Gmail SMTP relay that takes ~30 s to time out — the
+        # actual worst-case for ``smtplib.SMTP(..., timeout=30)``. The
+        # ticket-creation call must return well before the send finishes.
+        # ``_enqueue_email`` honours DISABLE_BACKGROUND_THREADS in tests,
+        # so temporarily disable that hatch for this one case to exercise
+        # the daemon-thread path.
+        import time
+
+        slow_call_started = threading.Event()
+        slow_call_can_return = threading.Event()
+
+        def _slow_send_email(subject, body, to=None):
+            slow_call_started.set()
+            # Bound the wait so a bug in the test still lets it exit.
+            slow_call_can_return.wait(timeout=10)
+            return True
+
+        self.notifications.send_email.side_effect = _slow_send_email
+        svc = TicketService(self.config, self.storage, self.notifications, jira=None)
+
+        prior = os.environ.pop("DISABLE_BACKGROUND_THREADS", None)
+        try:
+            start = time.monotonic()
+            ticket = svc.create_ticket(
+                {"title": "Heater", "description": "Cold"},
+                submitter_email="renter@example.com",
+            )
+            elapsed = time.monotonic() - start
+        finally:
+            slow_call_can_return.set()
+            if prior is not None:
+                os.environ["DISABLE_BACKGROUND_THREADS"] = prior
+
+        # If the send were on the request thread we'd have blocked for the
+        # full timeout. Give the assertion a wide margin (1 s) so slow CI
+        # boxes don't flake, while still catching an accidental sync send.
+        self.assertLess(elapsed, 1.0)
+        self.assertIn("id", ticket)
+        # Sanity: the daemon thread did actually kick off the send.
+        self.assertTrue(slow_call_started.wait(timeout=5))
+
+    def test_email_send_error_does_not_break_ticket_creation(self):
+        # A raise from ``send_email`` inside the daemon thread must not
+        # propagate to the caller.
+        self.notifications.send_email.side_effect = RuntimeError("SMTP down")
+        svc = TicketService(self.config, self.storage, self.notifications, jira=None)
+        ticket = svc.create_ticket(
+            {"title": "Heater", "description": "Cold"},
+            submitter_email="renter@example.com",
         )
         self.assertIn("id", ticket)
 

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -924,6 +924,55 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Maple House", response.data)
 
+    def test_renter_dashboard_backfill_preserves_concurrent_contract_writes(self):
+        """The id-backfill path must not overwrite a newer version of the
+        renter's contract list that an admin write installed between the
+        initial (unlocked) read and the persist-inside-``atomic()`` call.
+
+        Regression guard: prior code saved the pre-lock snapshot back,
+        silently dropping any contract added or removed in between.
+        """
+        self.login_as("renter", email="renter@example.com")
+        # Pre-lock snapshot: one contract without an ``id`` so the backfill
+        # actually persists a write.
+        original_snapshot = {
+            "renter@example.com": [{"property_name": "Old House"}],
+        }
+        # Fresh state observed inside the storage lock: the same renter now
+        # also has a brand-new contract added concurrently by an admin.
+        fresh_state = {
+            "renter@example.com": [
+                {"property_name": "Old House"},
+                {"property_name": "New House", "id": "existing-id"},
+            ],
+        }
+        # ``get_renter_contracts`` is called twice — first pre-lock, then
+        # again inside the atomic() to re-read the fresh list. Return the
+        # stale snapshot first and the fresh state second.
+        calls = {"n": 0}
+
+        def _get_contracts():
+            calls["n"] += 1
+            return original_snapshot if calls["n"] == 1 else fresh_state
+
+        with patch.object(
+            self.services.storage,
+            "get_renter_contracts",
+            side_effect=_get_contracts,
+        ), patch.object(
+            self.services.storage,
+            "save_renter_contracts",
+        ) as save_mock:
+            response = self.client.get("/renter-dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        # The concurrent contract must have survived the backfill.
+        save_mock.assert_called_once()
+        saved = save_mock.call_args[0][0]
+        saved_names = [c.get("property_name") for c in saved.get("renter@example.com", [])]
+        self.assertIn("Old House", saved_names)
+        self.assertIn("New House", saved_names)
+
     def test_renter_profile_loads_existing_profile(self):
         self.login_as("renter", email="renter@example.com")
         with patch.object(


### PR DESCRIPTION
## Summary

Two backend improvements found during the daily maintenance pass:

### 1. Ticket-creation emails now run on a daemon thread

`TicketService` previously invoked `notifications.send_email` synchronously in the create/update/note flows (admin inbox, submitter confirmation, status updates, renter-note fan-out). Gmail SMTP has a 30 s socket timeout, so a slow or unreachable relay could stall the calling request thread for up to a minute per ticket-creation POST — the existing `try/except` around the send only guards against exceptions, not latency, and the comment `notifications must not block ticket creation` was only half-true.

A new `_enqueue_email` helper mirrors the JIRA-mirror pattern already in the file: dispatches to a daemon thread by default and honours `DISABLE_BACKGROUND_THREADS=1` so unit tests still see synchronous sends. Every `send_email` call inside `tickets.py` now goes through it.

### 2. `_backfill_contract_ids` no longer clobbers concurrent writes

`renter_dashboard` used to read the renter's contract list outside the storage lock, then write the same snapshot back inside `services.storage.atomic()`. If an admin added or removed a contract for the same renter between the initial read and the atomic block, that concurrent write was silently lost — the same lost-update pattern commit `e062313` fixed for tickets and pending registrations.

The backfill now re-reads the fresh list inside the lock and stamps IDs on that, so any concurrent admin write survives.

## Test plan

- [x] `python -m unittest discover` — 840 tests pass (837 baseline + 3 new)
- [x] `ruff check .` — clean
- [x] New test `test_slow_smtp_does_not_block_ticket_creation` proves the create path returns while a synthetic 10 s SMTP send is still running (assertion: elapsed < 1 s)
- [x] New test `test_email_send_error_does_not_break_ticket_creation` verifies a raising SMTP backend doesn't propagate
- [x] New test `test_renter_dashboard_backfill_preserves_concurrent_contract_writes` proves the concurrent-add scenario now survives the backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2rDHfpPor9ygiZocjwddH

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2rDHfpPor9ygiZocjwddH)_