### PR TITLE
Dedupe upstream property IDs before fanout

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -561,7 +561,21 @@ class PropertyService:
         ids = payload.get("property_ids", [])
         if not isinstance(ids, list):
             return []
-        return [item for item in ids if isinstance(item, str)]
+        # Dedupe while preserving first-seen order. If upstream ever returns
+        # the same id twice (a transient replication artifact, or a bug in the
+        # ID-listing Lambda), a plain pass-through fans out to the details
+        # endpoint twice for that id AND leaves two copies of the same
+        # property in the cache — ``/for-rent`` then renders duplicate cards
+        # and ``get_property()`` only ever surfaces the first match. Enforce
+        # uniqueness at the boundary so both symptoms are impossible.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for item in ids:
+            if not isinstance(item, str) or item in seen:
+                continue
+            seen.add(item)
+            deduped.append(item)
+        return deduped
 
     def fetch_property_record(self, property_id: str):
         # Defense in depth: refuse property IDs that don't match the expected

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -439,6 +439,24 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(property_ids, ["prop-1", "prop-2"])
         response.raise_for_status.assert_called_once()
 
+    def test_fetch_property_ids_dedupes_duplicate_upstream_returns(self):
+        # Belt-and-braces at the upstream boundary: if the ID-listing Lambda
+        # ever returns the same id twice (transient replication, upstream
+        # bug), a plain pass-through would fan out per-property fetches
+        # twice AND leave two copies of the property in the cache — the
+        # ``/for-rent`` page then shows duplicate cards and
+        # ``get_property()`` only ever surfaces the first match. First-seen
+        # order is preserved so tests / logs stay deterministic.
+        response = Mock()
+        response.json.return_value = {
+            "property_ids": ["prop-1", "prop-2", "prop-1", "prop-3", "prop-2"]
+        }
+
+        with patch("somewheria_app.services.properties.requests.get", return_value=response):
+            property_ids = self.service._fetch_property_ids()
+
+        self.assertEqual(property_ids, ["prop-1", "prop-2", "prop-3"])
+
     def test_fetch_property_ids_raises_upstream_unavailable_on_failure(self):
         # A network/HTTP failure must surface as ``UpstreamUnavailable`` so
         # ``refresh_cache`` can leave the existing cache in place. Returning


### PR DESCRIPTION
## Summary

If the upstream ID-listing Lambda ever returns the same property id twice (transient replication artifact, upstream bug), a plain pass-through fans out to the details endpoint twice for that id AND leaves two copies of the same property in the cache — the `/for-rent` page then renders duplicate cards and `get_property()` only ever surfaces the first match.

Enforce uniqueness at the upstream boundary in `_fetch_property_ids` (preserving first-seen order), so both symptoms are impossible regardless of what upstream returns.

## Changes

- `somewheria_app/services/properties.py`: dedupe the ids returned by `_fetch_property_ids` while preserving first-seen order.
- `test_coverage_full.py`: regression test that a duplicated id in the upstream payload collapses to a single entry.

## Test plan

- [x] `python -m unittest discover` — 838 tests pass (was 837, plus the new one).
- [x] `ruff check .` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHd6Hab9yXA1F9nkYNEsMb)_