### PR TITLE
Truncate the fact-based property meta description like the blurb path

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -106,16 +106,29 @@ def for_rent_refresh_json():
     return jsonify(services.properties.serialize_properties(services.properties.get_visible_properties()))
 
 
+# Google typically shows the first ~155-160 characters of a page's meta
+# description in search results and truncates the rest. Cap both meta paths
+# at the same ceiling so search snippets aren't cut mid-word.
+_META_DESCRIPTION_MAX = 158
+_META_DESCRIPTION_TRUNCATE_AT = _META_DESCRIPTION_MAX - 1  # room for the ellipsis
+
+
+def _truncate_meta_description(text: str) -> str:
+    if len(text) <= _META_DESCRIPTION_MAX:
+        return text
+    return text[:_META_DESCRIPTION_TRUNCATE_AT].rstrip() + "…"
+
+
 def _property_meta_description(prop: dict) -> str:
     """A concise, factual search-result summary for one listing.
 
     Prefers the listing's own blurb/description; otherwise builds one from the
-    structured facts. Kept near ~155 chars, the length Google typically shows.
+    structured facts. Both paths are capped at ~158 chars — the length Google
+    typically shows before truncating in search results.
     """
     blurb = (prop.get("blurb") or prop.get("description") or "").strip()
     if blurb:
-        summary = " ".join(blurb.split())
-        return summary[:157].rstrip() + "…" if len(summary) > 158 else summary
+        return _truncate_meta_description(" ".join(blurb.split()))
 
     name = (prop.get("name") or "Rental home").strip()
     bits = []
@@ -136,7 +149,10 @@ def _property_meta_description(prop: dict) -> str:
     address = (prop.get("address") or "").strip()
     lead = f"{name} — " + ", ".join(bits) if bits else name
     tail = f" in {address}." if address and address != "N/A" else "."
-    return f"{lead}{tail} Available to rent from Somewheria, LLC. See photos and details, or request a tour."
+    return _truncate_meta_description(
+        f"{lead}{tail} Available to rent from Somewheria, LLC. "
+        "See photos and details, or request a tour."
+    )
 
 
 def property_details(uuid):

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -2042,5 +2042,92 @@ class LazyFileStatusTestCase(unittest.TestCase):
         self.assertIn("not writable", status["detail"])
 
 
+class PropertyMetaDescriptionTestCase(unittest.TestCase):
+    """Search-snippet builder is capped at Google's ~158-char display width.
+
+    Both the blurb-derived path AND the fact-derived fallback must respect
+    the cap: a listing without a blurb whose name and address are moderately
+    long would otherwise render a 200+ char meta description that gets cut
+    mid-word in search results.
+    """
+
+    def _describe(self, **prop):
+        from somewheria_app.routes.public_routes import (
+            _META_DESCRIPTION_MAX,
+            _property_meta_description,
+        )
+
+        return _property_meta_description(prop), _META_DESCRIPTION_MAX
+
+    def test_short_blurb_passes_through_unchanged(self):
+        desc, _ = self._describe(blurb="Sunlit two-bedroom near the park.")
+        self.assertEqual(desc, "Sunlit two-bedroom near the park.")
+
+    def test_blurb_collapses_internal_whitespace(self):
+        desc, _ = self._describe(blurb="Sunlit  two-bedroom\nnear the park.")
+        self.assertEqual(desc, "Sunlit two-bedroom near the park.")
+
+    def test_blurb_at_cap_is_not_truncated(self):
+        blurb = "x" * 158
+        desc, cap = self._describe(blurb=blurb)
+        self.assertEqual(desc, blurb)
+        self.assertEqual(len(desc), cap)
+
+    def test_long_blurb_is_truncated_with_ellipsis(self):
+        blurb = "x" * 400
+        desc, cap = self._describe(blurb=blurb)
+        self.assertLessEqual(len(desc), cap)
+        self.assertTrue(desc.endswith("…"))
+
+    def test_description_used_when_blurb_missing(self):
+        desc, _ = self._describe(description="Quiet corner unit with parking.")
+        self.assertEqual(desc, "Quiet corner unit with parking.")
+
+    def test_fact_fallback_is_truncated_for_long_name_and_address(self):
+        # Without a blurb, the fact-based fallback used to concatenate the
+        # name, structured facts, address, AND a marketing sentence — a
+        # long-named listing on a long-addressed street would blow past the
+        # ~155-char snippet window Google displays. The cap now applies to
+        # this path too, so search snippets aren't cut mid-word.
+        desc, cap = self._describe(
+            name="Beautifully Renovated Modern Rambler-Style House",
+            bedrooms="4",
+            bathrooms="3",
+            rent="2500",
+            address="12345 Northeast Broadway Street, Metropolitan City, Some State",
+        )
+        self.assertLessEqual(len(desc), cap)
+        self.assertTrue(desc.endswith("…"))
+
+    def test_fact_fallback_trims_trailing_rent_zero(self):
+        # Rent comes back from upstream as a float; the fallback should read
+        # "$1500/mo" not "$1500.0/mo".
+        desc, _ = self._describe(
+            name="Maple House",
+            bedrooms="2",
+            bathrooms="1",
+            rent=1500.0,
+            address="123 Main St",
+        )
+        self.assertIn("$1500/mo", desc)
+        self.assertNotIn("$1500.0/mo", desc)
+
+    def test_fact_fallback_uses_default_name(self):
+        desc, _ = self._describe(bedrooms="1", bathrooms="1")
+        self.assertTrue(desc.startswith("Rental home"))
+
+    def test_missing_fields_are_omitted(self):
+        # "N/A" placeholders should not appear as literal text in the snippet.
+        desc, _ = self._describe(
+            name="Maple House",
+            bedrooms="N/A",
+            bathrooms="N/A",
+            rent="N/A",
+            address="N/A",
+        )
+        self.assertNotIn("N/A", desc)
+        self.assertNotIn(" in .", desc)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`_property_meta_description` in `somewheria_app/routes/public_routes.py` already capped blurb-derived summaries at ~158 chars — the length Google typically shows in search results before truncating — but the fact-derived fallback (used when a listing has no blurb) concatenated the name, structured facts, address, AND a marketing sentence and returned the whole string uncapped. A moderately long name plus address blew past 200 chars and got cut mid-word in search snippets.

This PR extracts the truncation into a shared `_truncate_meta_description` helper and applies it to both paths so either route yields a snippet that fits inside Google's display window.

## Changes

- `somewheria_app/routes/public_routes.py`
  - New `_truncate_meta_description` helper + `_META_DESCRIPTION_MAX` constant (158) with an ellipsis-aware truncation slot.
  - Blurb path now uses the helper (behavior unchanged).
  - Fact-based fallback now runs through the same helper — this is the behavior fix.
- `test_routes_expanded.py`
  - New `PropertyMetaDescriptionTestCase` with 9 tests covering: short blurb passthrough, whitespace collapsing, cap boundary (158 chars), long-blurb truncation, description-fallback when blurb is missing, fact-fallback truncation for long name+address, trailing `.0` trimming on rent, default name for empty listings, and `N/A` placeholders being omitted.

## Test plan

- [x] `python -m unittest discover` — 847 tests pass (was 838; +9 new).
- [x] `ruff check .` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tff2Pxyhm5G6wuet2gbYzC)_