### PR TITLE
Validate contract dates on admin add

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -761,6 +761,23 @@ def renter_profile():
     return render_template("renter_profile.html", profile=profile, user=user, success=success, title="Edit Profile")
 
 
+def _valid_iso_date(value: str) -> bool:
+    """Return True if ``value`` is a strict YYYY-MM-DD calendar date.
+
+    ``date.fromisoformat`` on 3.11+ accepts other ISO 8601 shapes (with a
+    time component, week dates, ordinal dates); admin contracts store the
+    date-only form, so we enforce that shape explicitly rather than
+    relying on the parser's incidental strictness.
+    """
+    if not isinstance(value, str) or len(value) != 10:
+        return False
+    try:
+        datetime.date.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
 def _validate_contract_pdf(uploaded_file) -> bytes | None:
     """Read the upload, validate as a PDF (magic bytes + size). Returns bytes
     on success or None when no file was supplied. Raises ValueError on bad
@@ -822,6 +839,20 @@ def admin_contracts():
                 # creates an orphan contract that no real OAuth login can
                 # ever surface for the renter.
                 error = "A valid renter email is required."
+            elif not _valid_iso_date(start_date) or not _valid_iso_date(end_date):
+                # Reject garbage date strings at the boundary. The <input
+                # type="date"> field normalizes to YYYY-MM-DD, so a bad value
+                # here is a hand-crafted POST or a paste error — either way
+                # ``_classify_contract_status`` would silently swallow the
+                # parse failure downstream and the admin dashboard would
+                # render the literal junk string as the contract's term.
+                error = "Start and end dates must be YYYY-MM-DD."
+            elif datetime.date.fromisoformat(end_date) < datetime.date.fromisoformat(start_date):
+                # A contract whose end precedes its start is nonsense and
+                # would classify as "ended" the moment it's saved. Rejecting
+                # here catches the most likely typo (year swap, month swap)
+                # while the admin still has the form open to correct it.
+                error = "End date must not be before start date."
             else:
                 contract_id = uuid_lib.uuid4().hex
                 pdf_filename = ""

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -1042,6 +1042,82 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"Contract added for renter@example.com.", response.data)
         save_contracts_mock.assert_called_once()
 
+    def test_admin_contracts_add_rejects_malformed_dates(self):
+        # A hand-crafted POST (or a paste-error) with a non-ISO date must be
+        # rejected at the boundary so garbage never lands in
+        # renter_contracts storage. Downstream _classify_contract_status
+        # silently swallows parse failures, so without this the admin sees
+        # the literal junk string rendered as the contract's term.
+        self.login_as("admin")
+        with patch.object(self.services.storage, "get_renter_contracts", return_value={}), patch.object(
+            self.services.storage,
+            "save_renter_contracts",
+        ) as save_contracts_mock:
+            response = self.client.post(
+                "/admin/contracts",
+                data={
+                    "action": "add",
+                    "renter_email": "renter@example.com",
+                    "property_name": "Maple House",
+                    "start_date": "2030-13-40",  # invalid month/day
+                    "end_date": "2030-12-31",
+                    "status": "Active",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"YYYY-MM-DD", response.data)
+        save_contracts_mock.assert_not_called()
+
+    def test_admin_contracts_add_rejects_end_before_start(self):
+        # Contracts whose end precedes their start are nonsense and would
+        # classify as "ended" the moment they're saved. The most common
+        # cause is a year/month swap the admin should be told to fix.
+        self.login_as("admin")
+        with patch.object(self.services.storage, "get_renter_contracts", return_value={}), patch.object(
+            self.services.storage,
+            "save_renter_contracts",
+        ) as save_contracts_mock:
+            response = self.client.post(
+                "/admin/contracts",
+                data={
+                    "action": "add",
+                    "renter_email": "renter@example.com",
+                    "property_name": "Maple House",
+                    "start_date": "2030-12-31",
+                    "end_date": "2030-01-01",
+                    "status": "Active",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"End date must not be before start date.", response.data)
+        save_contracts_mock.assert_not_called()
+
+    def test_admin_contracts_add_accepts_same_start_and_end(self):
+        # A one-day contract is unusual but valid; end >= start (not strict >)
+        # is the correct predicate.
+        self.login_as("admin")
+        with patch.object(self.services.storage, "get_renter_contracts", return_value={}), patch.object(
+            self.services.storage,
+            "save_renter_contracts",
+        ) as save_contracts_mock:
+            response = self.client.post(
+                "/admin/contracts",
+                data={
+                    "action": "add",
+                    "renter_email": "renter@example.com",
+                    "property_name": "Maple House",
+                    "start_date": "2030-06-15",
+                    "end_date": "2030-06-15",
+                    "status": "Active",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Contract added for renter@example.com.", response.data)
+        save_contracts_mock.assert_called_once()
+
     def test_admin_contracts_delete_rejects_invalid_index(self):
         self.login_as("admin")
         with patch.object(


### PR DESCRIPTION
## Summary

The `admin_contracts` "add" action truncated `start_date` / `end_date` to 32 chars and stored them as-is with no format check. A hand-crafted POST — or a paste-error into what should be an `<input type="date">` — could push any string into `renter_contracts` storage; downstream `_classify_contract_status` silently swallows the parse failure, so the admin dashboard renders the literal junk string as the contract's term. A year/month swap that made `end_date < start_date` would also be silently accepted and immediately re-classified as "ended".

This PR rejects both at the boundary:
- Enforce strict `YYYY-MM-DD` on both fields via a new `_valid_iso_date` helper (10-char length + `date.fromisoformat`).
- Require `end_date >= start_date` so a one-day contract still validates but an inverted range does not.

Existing tests continue to cover the happy path; three new cases pin the new behavior:
- malformed date (`2030-13-40`) → 200 with `YYYY-MM-DD` error, storage untouched
- end before start → 200 with the ordering error, storage untouched
- start == end → happy path (predicate is `>=`, not strict `>`)

The CSV export test that intentionally hand-injects `"+1"` / `"-1"` into storage keeps passing because it patches `get_renter_contracts` directly and never goes through the add path.

## Test plan

- [x] `python -m unittest discover` — 850 passing, 1 skipped
- [x] Manually walked the flow: bad date → visible admin error, storage not written; inverted range → visible admin error, storage not written; equal dates → contract added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qh1Uf9xMRPJW2DUzaUwNGX)_