### PR TITLE
Exclude revoked user tombstones from admin summary counts

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -310,10 +310,15 @@ def admin_status():
     def route_ready(*endpoints):
         return all(endpoint in registered_routes for endpoint in endpoints)
 
+    # Exclude "revoked" tombstones from the count: they're deleted users
+    # kept only so an .env-based role can't silently restore access on the
+    # next login. Counting them here would show a growing "known users"
+    # total that includes people with no access.
+    active_user_count = sum(1 for role in user_roles.values() if role != "revoked")
     metrics = {
         "properties_cached": property_count,
         "pending_registrations": len(pending_registrations),
-        "known_users": len(user_roles),
+        "known_users": active_user_count,
         "cache_refresh_interval": f"{config.cache_refresh_interval}s",
     }
 
@@ -540,12 +545,20 @@ def admin_dashboard_combined():
     ticket_summary = services.tickets.summary()
     ticket_status_counts = services.tickets.status_counts()
     listing_activity = services.analytics.recent_listing_activity(months=12)
+    # Skip "revoked" tombstones: they represent deleted users whose access
+    # is gone. Left in the list, the template's role tally counts them as
+    # renters (its else branch is renter) and inflates the total user count.
+    active_user_roles = [
+        (email, role)
+        for email, role in services.storage.get_user_roles().items()
+        if role != "revoked"
+    ]
     return render_template(
         "admin_dashboard.html",
         user=get_current_user(),
         metrics=metrics,
         chart_data=chart_data,
-        users=list(services.storage.get_user_roles().items()),
+        users=active_user_roles,
         ticket_summary=ticket_summary,
         ticket_status_counts=ticket_status_counts,
         listing_activity=listing_activity,

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -912,6 +912,68 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"valid email is required", response.data)
         set_user_role_mock.assert_not_called()
 
+    def test_admin_dashboard_excludes_revoked_users_from_summary(self):
+        # A "revoked" tombstone is a deleted user kept only so an env role
+        # can't silently restore access on the next login. Passing it into
+        # the dashboard "users" list would count it as a renter (the
+        # template's role tally is admin/high_admin/else, so any other role
+        # — including "revoked" — falls into the renter bucket) and inflate
+        # the total user count. The route must strip revoked entries.
+        self.login_as("high_admin", email="owner@example.com")
+        stored_roles = {
+            "active_renter@example.com": "renter",
+            "deleted@example.com": "revoked",
+        }
+        with patch.object(
+            self.services.analytics,
+            "dashboard_data",
+            return_value=({"visits": 0}, {"labels": []}),
+        ), patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value=stored_roles,
+        ), patch(
+            "somewheria_app.routes.admin_routes.render_template",
+            return_value="ok",
+        ) as render_mock:
+            response = self.client.get("/admin/dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        kwargs = render_mock.call_args.kwargs
+        users = kwargs["users"]
+        self.assertEqual(users, [("active_renter@example.com", "renter")])
+        for _, role in users:
+            self.assertNotEqual(role, "revoked")
+
+    def test_admin_status_excludes_revoked_users_from_known_users_count(self):
+        # Mirrors the dashboard fix: /admin/status's "known_users" metric
+        # is the size of the persistent user_roles map, but revoked
+        # tombstones represent deleted users and must not be counted.
+        self.login_as("high_admin", email="owner@example.com")
+        stored_roles = {
+            "one@example.com": "renter",
+            "two@example.com": "admin",
+            "revoked1@example.com": "revoked",
+            "revoked2@example.com": "revoked",
+        }
+        with patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value=stored_roles,
+        ), patch.object(
+            self.services.storage,
+            "get_pending_registrations",
+            return_value=[],
+        ), patch(
+            "somewheria_app.routes.admin_routes.render_template",
+            return_value="ok",
+        ) as render_mock:
+            response = self.client.get("/admin/status")
+
+        self.assertEqual(response.status_code, 200)
+        kwargs = render_mock.call_args.kwargs
+        self.assertEqual(kwargs["metrics"]["known_users"], 2)
+
     def test_renter_dashboard_loads_for_renter(self):
         self.login_as("renter", email="renter@example.com")
         with patch.object(


### PR DESCRIPTION
## Summary

`/admin/dashboard`'s user summary and `/admin/status`'s `known_users` metric both counted `role == "revoked"` tombstones — the entries that `FileStorageService.delete_user_role` writes so a deleted admin can't be silently reinstated by an .env fallback on their next login.

Worse, the dashboard template's role tally is:
```jinja
{% if role == 'high_admin' %}...
{% elif role == 'admin' %}...
{% else %}renter += 1{% endif %}
```
So every deactivated user was counted as a renter, inflating the "N renter" badge whenever an admin deactivated anyone.

This PR filters tombstones out where the routes build the metric/list, so the counts reflect users who actually still have access. No template changes.

## Changes

- `somewheria_app/routes/admin_routes.py`
  - `admin_status`: compute `known_users` as the count of user_roles entries whose role isn't `"revoked"`.
  - `admin_dashboard_combined`: build the `users` list passed to the template excluding revoked entries.
- `test_routes_expanded.py`: add two regression tests — one asserting the dashboard's `users` context excludes revoked entries, one asserting `known_users` on `/admin/status` counts only active roles.

## Test plan

- [x] `python -m unittest test_routes_expanded.ExpandedRouteCoverageTestCase.test_admin_dashboard_excludes_revoked_users_from_summary` — passes
- [x] `python -m unittest test_routes_expanded.ExpandedRouteCoverageTestCase.test_admin_status_excludes_revoked_users_from_known_users_count` — passes
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 852 tests pass (2 new + 850 existing), 1 skipped, no failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rk4tmQFi6DUHV4jWmD9TYA)_