### PR TITLE
Pluralize bed/bath counts in the fact-based meta description

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -119,6 +119,20 @@ def _truncate_meta_description(text: str) -> str:
     return text[:_META_DESCRIPTION_TRUNCATE_AT].rstrip() + "…"
 
 
+def _pluralize_count(count, singular: str) -> str:
+    # "2 bed" and "3 bath" read wrong to a human eye and land in Google
+    # search snippets exactly that way — meta_description is what the crawler
+    # sees for the fact-fallback path. Pluralize only when the count parses
+    # as a number != 1 (so free-form values like "Studio" fall through as-is
+    # rather than becoming "Studios").
+    try:
+        numeric = float(count)
+    except (TypeError, ValueError):
+        return f"{count} {singular}"
+    label = singular if numeric == 1 else f"{singular}s"
+    return f"{count} {label}"
+
+
 def _property_meta_description(prop: dict) -> str:
     """A concise, factual search-result summary for one listing.
 
@@ -134,9 +148,9 @@ def _property_meta_description(prop: dict) -> str:
     bits = []
     beds, baths = prop.get("bedrooms"), prop.get("bathrooms")
     if beds not in (None, "", "N/A"):
-        bits.append(f"{beds} bed")
+        bits.append(_pluralize_count(beds, "bed"))
     if baths not in (None, "", "N/A"):
-        bits.append(f"{baths} bath")
+        bits.append(_pluralize_count(baths, "bath"))
     rent = prop.get("rent")
     if rent not in (None, "", "N/A"):
         # Trim a trailing ".0" the upstream sends (rent comes back as a float),

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -2266,6 +2266,60 @@ class PropertyMetaDescriptionTestCase(unittest.TestCase):
         self.assertNotIn("N/A", desc)
         self.assertNotIn(" in .", desc)
 
+    def test_fact_fallback_pluralizes_bed_and_bath_counts(self):
+        # The fact-based path used to emit "{n} bed" / "{n} bath" regardless
+        # of count, so a 2-bedroom listing without a blurb read "2 bed" in
+        # Google's search snippet. Match natural English: singular only when
+        # the count is exactly 1.
+        desc, _ = self._describe(
+            name="Maple House",
+            bedrooms="2",
+            bathrooms="3",
+            address="123 Main St",
+        )
+        self.assertIn("2 beds", desc)
+        self.assertNotIn("2 bed,", desc)
+        self.assertIn("3 baths", desc)
+        self.assertNotIn("3 bath,", desc)
+        self.assertNotIn("3 bath ", desc)
+
+    def test_fact_fallback_keeps_singular_for_one(self):
+        # Both string "1" and int 1 count as singular; a half-count like 1.5
+        # is plural.
+        for beds, baths in (("1", "1"), (1, 1)):
+            desc, _ = self._describe(
+                name="Maple House",
+                bedrooms=beds,
+                bathrooms=baths,
+                address="123 Main St",
+            )
+            self.assertIn(f"{beds} bed,", desc)
+            self.assertIn(f"{baths} bath ", desc + " ")
+            self.assertNotIn("beds", desc)
+            self.assertNotIn("baths", desc)
+
+    def test_fact_fallback_pluralizes_half_baths(self):
+        desc, _ = self._describe(
+            name="Maple House",
+            bedrooms="2",
+            bathrooms="1.5",
+            address="123 Main St",
+        )
+        self.assertIn("1.5 baths", desc)
+
+    def test_fact_fallback_passes_through_non_numeric_bedrooms(self):
+        # Free-form values (e.g. "Studio") don't parse as numbers; leave them
+        # alone rather than tacking on an "s".
+        desc, _ = self._describe(
+            name="Loft",
+            bedrooms="Studio",
+            bathrooms="1",
+            address="123 Main St",
+        )
+        self.assertIn("Studio bed", desc)
+        self.assertNotIn("Studios", desc)
+        self.assertNotIn("Studio beds", desc)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The fact-fallback path in `_property_meta_description` (in `somewheria_app/routes/public_routes.py`) emitted `{n} bed` / `{n} bath` regardless of count, so a 2-bedroom, 3-bath listing without a blurb rendered `2 bed, 3 bath` in Google's search snippet — the exact text a crawler sees for the fact-fallback path.

## Changes

- Added a small `_pluralize_count` helper that returns singular only when the count parses to exactly `1`; free-form values like `Studio` fall through as-is rather than becoming `Studios`.
- Applied it to the bed / bath bullets in the fact fallback.
- Added test cases for: plural counts (`2 beds`, `3 baths`), singular for both `1` (str) and `1` (int), half-baths (`1.5 baths`), and free-form values (`Studio bed` — untouched).

## Test plan

- [x] `python -m unittest test_routes_expanded.PropertyMetaDescriptionTestCase` — 13/13 pass, including the four new pluralization cases.
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover -q` — full suite: 856 tests, all pass (1 pre-existing skip).
- [x] Existing fact-fallback tests (`test_fact_fallback_trims_trailing_rent_zero`, `test_fact_fallback_is_truncated_for_long_name_and_address`, `test_missing_fields_are_omitted`) still pass with the new pluralized output.

Backend-only change, no templates touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPGpD9N6cPZKFje1cE65aa)_