### PR TITLE
Serve appointment scheduling from cache when the property is present

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -225,7 +225,16 @@ def schedule_appointment(uuid):
             error=f"Date must be within {MAX_APPOINTMENT_DAYS_AHEAD} days.",
         ), 400
 
-    property_name = services.properties.fetch_live_property_name(uuid)
+    # Cache-first: /for-rent refreshes on every hit and the visitor almost
+    # certainly landed here from a property page (which populates the cache),
+    # so the id is nearly always present. Skipping the upstream API call on
+    # the happy path saves an AWS Lambda round-trip per appointment request
+    # and lets viewings still be booked during a brief upstream outage for
+    # any listing already in the cache. Fall through to the live fetch only
+    # when the id isn't cached (cold start, direct-link visitor, etc.).
+    property_name = services.properties.get_property_name(uuid)
+    if not property_name:
+        property_name = services.properties.fetch_live_property_name(uuid)
     if not property_name:
         return jsonify(success=False, error="Property not found."), 404
 

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -369,6 +369,60 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "That date is already booked.")
         send_email_mock.assert_not_called()
 
+    def test_schedule_appointment_uses_cached_property_name_when_present(self):
+        # Cached properties should not require a live upstream fetch. Skipping
+        # the outbound call saves an AWS Lambda round-trip per appointment
+        # request and lets viewings still be booked during a brief upstream
+        # outage for any listing the site has recently rendered.
+        self.seed_property(property_id="prop-1", name="Cached House")
+        future_date = (datetime.date.today() + datetime.timedelta(days=5)).isoformat()
+        with patch.object(
+            self.services.properties, "fetch_live_property_name"
+        ) as live_fetch_mock, patch.object(
+            self.services.appointments, "book", return_value=True
+        ), patch.object(self.services.notifications, "send_email") as send_email_mock:
+            response = self.client.post(
+                "/property/prop-1/schedule",
+                json={
+                    "name": "Alex",
+                    "date": future_date,
+                    "contact_method": "email",
+                    "contact_info": "alex@example.com",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"success": True})
+        live_fetch_mock.assert_not_called()
+        send_email_mock.assert_called_once()
+        self.assertIn("Cached House", send_email_mock.call_args[0][1])
+
+    def test_schedule_appointment_falls_back_to_live_fetch_when_uncached(self):
+        # Cold-cache / direct-link case: the id isn't in the local cache, so
+        # the route should still verify the property exists upstream instead
+        # of silently 404ing before the live check.
+        future_date = (datetime.date.today() + datetime.timedelta(days=5)).isoformat()
+        with patch.object(
+            self.services.properties,
+            "fetch_live_property_name",
+            return_value="Live House",
+        ) as live_fetch_mock, patch.object(
+            self.services.appointments, "book", return_value=True
+        ), patch.object(self.services.notifications, "send_email") as send_email_mock:
+            response = self.client.post(
+                "/property/prop-uncached/schedule",
+                json={
+                    "name": "Alex",
+                    "date": future_date,
+                    "contact_method": "email",
+                    "contact_info": "alex@example.com",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        live_fetch_mock.assert_called_once_with("prop-uncached")
+        self.assertIn("Live House", send_email_mock.call_args[0][1])
+
     def test_about_page_loads(self):
         response = self.client.get("/about")
 


### PR DESCRIPTION
## Summary

`schedule_appointment` unconditionally fired a live upstream Lambda call to fetch the property's display name, even for listings that were already in the local cache from the visitor's own `/property/<uuid>` page render (which /for-rent's synchronous refresh had just populated).

Try `PropertyService.get_property_name` first and only fall through to `fetch_live_property_name` when the id isn't cached — the fallback preserves the cold-cache and direct-link behavior.

Effects:
- Skips one AWS API Gateway / Lambda round-trip per appointment request on the happy path (cost + latency win, consistent with the recent cache-only fixes on `main`).
- Viewings can still be booked during a brief upstream outage for any listing already in the local cache.
- No behavior change for uncached ids: the route still verifies against upstream before booking.

## Test plan

- [x] `python -m unittest discover` — 854 tests, 1 skipped (was 852 before; +2 new).
- [x] `ruff check .` — clean.
- [x] New tests exercise both paths:
  - `test_schedule_appointment_uses_cached_property_name_when_present` — asserts `fetch_live_property_name` is NOT called when the id is cached, and the cached name appears in the notification body.
  - `test_schedule_appointment_falls_back_to_live_fetch_when_uncached` — asserts the live fetch runs when the id is not cached.
- [x] Existing schedule-appointment tests (404, success, persistence, double-booking) still pass unchanged — they clear the cache in `setUp`, so the new code path falls through to the mocked `fetch_live_property_name` exactly as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jVz1JbhdpvU1ekUy7nnu5)_