### PR TITLE
Case-normalize analytics visitors and stabilize change-log diff order

### DIFF
--- a/somewheria_app/services/analytics.py
+++ b/somewheria_app/services/analytics.py
@@ -94,7 +94,14 @@ class AnalyticsTracker:
             return
         today = datetime.date.today().isoformat()
         user = session.get("user") or {}
-        visitor = user.get("email") or request.remote_addr or "anonymous"
+        # Case-normalize the email portion so a mixed-case login
+        # ("Sam@example.com") and its lowercased twin from record_login
+        # ("sam@example.com") collapse to the same key. Without this, the
+        # same visitor gets counted twice in unique_users on days they hit
+        # the site both anonymously (session cookie carries the case Google
+        # returned) and via record_login (which already lowercases).
+        email = (user.get("email") or "").strip().lower()
+        visitor = email or request.remote_addr or "anonymous"
         now = time.monotonic()
         with self._lock:
             self._prune_old_buckets(today)

--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -505,10 +505,20 @@ class PropertyService:
         changed = []
         current_by_id = by_id(current_properties)
         latest_by_id = by_id(latest_properties)
-        for property_id in old_ids & new_ids:
+        # Sort both the id traversal and the per-property fields list so
+        # identical semantic diffs produce byte-identical change-log entries.
+        # Set iteration order is unspecified in Python, which meant a
+        # cache_updated entry written twice from the same input carried
+        # different orderings of ``changed`` and ``fields`` — noise for
+        # anyone diffing site_changes.log between runs, and enough to flake
+        # equality assertions that happen to compare the serialized entry.
+        for property_id in sorted(old_ids & new_ids):
             old = current_by_id[property_id]
             new = latest_by_id[property_id]
-            diffs = [key for key in set(old.keys()).union(new.keys()) if old.get(key) != new.get(key)]
+            diffs = sorted(
+                key for key in set(old.keys()) | set(new.keys())
+                if old.get(key) != new.get(key)
+            )
             if diffs:
                 changed.append({"id": property_id, "fields": diffs})
         return {

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -419,6 +419,29 @@ class CoveragePropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(current, current_before)
         self.assertEqual(latest, latest_before)
 
+    def test_build_change_log_produces_deterministic_ordering(self):
+        # The diff is written into a JSONL change log and read back by
+        # analytics.recent_listing_activity. ``changed`` and each entry's
+        # ``fields`` list used to come out of set iteration, so identical
+        # inputs produced different byte outputs on every refresh — noise
+        # for anyone diffing site_changes.log. Both lists should be sorted
+        # so identical inputs produce byte-identical entries.
+        current = [
+            {"id": "prop-b", "name": "Old B", "rent": "1000", "description": "old"},
+            {"id": "prop-a", "name": "Old A", "rent": "900"},
+        ]
+        latest = [
+            {"id": "prop-b", "name": "New B", "rent": "1100", "description": "new"},
+            {"id": "prop-a", "name": "New A", "rent": "950"},
+        ]
+        first = self.service._build_change_log(current, latest)
+        second = self.service._build_change_log(current, latest)
+        self.assertEqual(first, second)
+        changed_ids = [entry["id"] for entry in first["changed"]]
+        self.assertEqual(changed_ids, sorted(changed_ids))
+        for entry in first["changed"]:
+            self.assertEqual(entry["fields"], sorted(entry["fields"]))
+
     def test_fetch_all_properties_filters_out_missing_records(self):
         with patch.object(self.service, "_fetch_property_ids", return_value=["prop-1", "prop-2"]), patch.object(
             self.service,
@@ -1317,6 +1340,24 @@ class CoverageAnalyticsAndFactoryTestCase(unittest.TestCase):
                 self.analytics.before_request()
 
         self.assertEqual(sum(self.analytics.site_visits.values()), 2)
+
+    def test_mixed_case_email_collapses_to_single_visitor(self):
+        # ``record_login`` (in auth_routes) passes a lowercased email, but
+        # the session cookie carries whatever case Google returned. Without
+        # case-normalizing the visitor key in ``before_request``, the same
+        # person shows up as two distinct entries in ``unique_users`` on
+        # days they visit both anonymously and after login.
+        for email in ("Sam@Example.com", "sam@example.com", "SAM@EXAMPLE.COM"):
+            with self.app.test_request_context("/hello", headers={"User-Agent": self.BROWSER_UA}):
+                from flask import session
+
+                session["user"] = {"email": email}
+                self.analytics.before_request()
+
+        self.assertEqual(sum(self.analytics.site_visits.values()), 1)
+        unique_today = next(iter(self.analytics.unique_users.values()))
+        self.assertEqual(len(unique_today), 1)
+        self.assertIn("sam@example.com", unique_today)
 
     def test_visit_counts_again_after_session_gap(self):
         from somewheria_app.services.analytics import VISIT_SESSION_GAP_SECONDS


### PR DESCRIPTION
## Summary

Two small correctness/hygiene fixes surfaced during a codebase sweep.

### 1. Analytics visitor case normalization (`somewheria_app/services/analytics.py`)

`AnalyticsTracker.before_request` keyed the visitor bucket off the raw session email, but `record_login` (called from `google_callback`) already lowercases before adding to `unique_users`. A single person visiting both anonymously and after logging in on the same day was counted as two distinct entries in `unique_users` — once as `Sam@example.com`, once as `sam@example.com` — and the `site_visits` counter double-counted the login-boundary visit as well because the two keys never collided in `_visitor_last_seen`.

Lowercase the email portion in `before_request` so both paths share the same key.

### 2. Deterministic change-log diff ordering (`somewheria_app/services/properties.py`)

`PropertyService._build_change_log` walked `old_ids & new_ids` and each entry's field diff via set iteration, whose order is unspecified in Python. Identical semantic inputs produced JSONL entries with different byte layout on every refresh — noise for anyone diffing `site_changes.log` between runs, and a subtle flake hazard for equality assertions that happened to compare the serialized entry.

Sort both traversals; `added_ids` / `removed_ids` were already sorted, so this brings the whole record to a stable order.

### Tests

- `test_mixed_case_email_collapses_to_single_visitor` in `CoverageAnalyticsAndFactoryTestCase` locks in the visitor collapse.
- `test_build_change_log_produces_deterministic_ordering` in `CoveragePropertyServiceTestCase` locks in stable diff output for identical inputs.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 854 tests, all pass (baseline was 852; +2 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKf8iYSDL7ComkEfTyyUE1)_