### PR TITLE
Correctly handle admin delete of env-configured users

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -491,17 +491,30 @@ def admin_dashboard_combined():
             error = "You cannot modify your own account here."
         elif action == "delete":
             target_role = services.auth.get_user_role(email)
-            if not _can_act_on(actor_role, target_role):
+            # Reject a delete against an email that has no access to remove BEFORE
+            # calling delete_user_role: storage writes a tombstone unconditionally
+            # (to block env-var fallbacks from restoring a real user's access on
+            # the next login), and letting a random typo through here would
+            # pollute user_roles storage with a permanent "revoked" entry for
+            # someone who was never a user in the first place.
+            if target_role == "guest":
+                error = "User not found."
+            elif not _can_act_on(actor_role, target_role):
                 error = "You cannot modify a user at or above your own role."
-            elif services.storage.delete_user_role(email):
+            else:
+                # The delete succeeds by side effect (the tombstone is what
+                # actually deactivates the account, including for env-configured
+                # users with no file entry). Its return value only reports
+                # whether a previous FILE entry existed — treating False as
+                # "user not found" swallowed the audit log and showed the wrong
+                # message whenever an admin deleted an env-only user.
+                services.storage.delete_user_role(email)
                 success = (
                     f"Deactivated {email} — their access is revoked, but their "
                     "contracts, profile, and tickets are kept. Re-add the email "
                     "to restore access."
                 )
                 services.notifications.log_site_change(actor_email, "user_deleted", {"email": email})
-            else:
-                error = "User not found."
         elif action == "update":
             new_role = request.form.get("role", "").strip()
             target_role = services.auth.get_user_role(email)
@@ -695,9 +708,20 @@ def admin_users():
         elif email == actor_email:
             error = "You cannot modify your own account here."
         elif action == "delete":
-            if not _can_act_on(actor_role, target_role):
+            # Reject a delete against an email that has no access to remove
+            # BEFORE calling delete_user_role — see the same guard in
+            # admin_dashboard_combined for the full rationale. Without this,
+            # a random typo tombstones a never-was-a-user email in
+            # user_roles storage; and an env-configured user being deleted
+            # silently succeeds via tombstone but shows "User not found."
+            # (delete_user_role returns False when there's no previous FILE
+            # entry) and skips the user_deleted audit log entry.
+            if target_role == "guest":
+                error = "User not found."
+            elif not _can_act_on(actor_role, target_role):
                 error = "You cannot modify a user at or above your own role."
-            elif services.storage.delete_user_role(email):
+            else:
+                services.storage.delete_user_role(email)
                 success = (
                     f"Deactivated {email} — their access is revoked, but their "
                     "contracts, profile, and tickets are kept. Re-add the email "
@@ -711,8 +735,6 @@ def admin_users():
                 services.notifications.log_site_change(
                     actor_email, "user_deleted", {"email": email}
                 )
-            else:
-                error = "User not found."
         elif new_role in ALLOWED_ROLES:
             # Defense in depth: reject malformed emails before they touch
             # user_roles storage. Delete is intentionally exempt so an admin

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -1675,11 +1675,15 @@ class CoverageRouteBranchTestCase(unittest.TestCase):
 
     def test_admin_dashboard_handles_branchy_post_paths(self):
         self.login_as("high_admin", email="owner@example.com")
+        # user@example.com is seeded with a real role so the delete's target
+        # existence check (target_role != "guest") passes; missing@example.com
+        # is intentionally absent so the same check rejects that delete before
+        # storage is touched.
         with patch.object(self.services.analytics, "dashboard_data", return_value=({}, {})), patch.object(
             self.services.storage,
             "get_user_roles",
-            return_value={"existing@example.com": "admin"},
-        ), patch.object(self.services.storage, "delete_user_role", side_effect=[True, False]), patch.object(
+            return_value={"existing@example.com": "admin", "user@example.com": "renter"},
+        ), patch.object(self.services.storage, "delete_user_role", return_value=True), patch.object(
             self.services.storage,
             "set_user_role",
         ) as set_role_mock, patch.object(self.services.notifications, "log_site_change") as change_mock:
@@ -1732,10 +1736,12 @@ class CoverageRouteBranchTestCase(unittest.TestCase):
 
     def test_admin_users_delete_success_and_invalid_role(self):
         self.login_as("admin")
+        # user@example.com is seeded so the delete's target existence check
+        # (target_role != "guest") passes and reaches storage.
         with patch.object(self.services.storage, "delete_user_role", return_value=True), patch.object(
             self.services.storage,
             "get_user_roles",
-            side_effect=[{}, {}, {}],
+            return_value={"user@example.com": "renter"},
         ):
             delete_response = self.client.post(
                 "/admin/users",

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -694,7 +694,7 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         with patch.object(self.services.storage, "delete_user_role", return_value=True), patch.object(
             self.services.storage,
             "get_user_roles",
-            return_value={},
+            return_value={"renter@example.com": "renter"},
         ), patch.object(self.services.notifications, "log_site_change") as log_mock:
             response = self.client.post(
                 "/admin/users",
@@ -707,6 +707,45 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
             "admin@example.com",
             "user_deleted",
             {"email": "renter@example.com"},
+        )
+
+    def test_admin_users_delete_env_configured_user_writes_audit_log(self):
+        # An env-configured user (in ADMIN_USERS / AUTHORIZED_USERS but with
+        # no user_roles.json entry) still has to be deactivatable through the
+        # admin UI: the tombstone delete_user_role writes IS what blocks the
+        # env fallback from restoring their role on the next login. Before
+        # this fix the route keyed off delete_user_role's boolean, which
+        # reports "no previous FILE entry" (False) whenever the user came
+        # from env — so the admin saw "User not found.", the audit log was
+        # skipped, and yet the user WAS actually deactivated. Pin the
+        # corrected behavior: Deactivated message + user_deleted audit
+        # entry, matching a file-only delete.
+        self.login_as("admin", email="admin@example.com")
+        with patch.object(
+            self.services.storage,
+            "delete_user_role",
+            return_value=False,  # simulates "no previous file entry"
+        ) as delete_mock, patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ), patch.object(
+            self.services.auth,
+            "get_user_role",
+            return_value="renter",  # env-configured role
+        ), patch.object(self.services.notifications, "log_site_change") as log_mock:
+            response = self.client.post(
+                "/admin/users",
+                data={"email": "envonly@example.com", "action": "delete"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Deactivated", response.data)
+        delete_mock.assert_called_once_with("envonly@example.com")
+        log_mock.assert_called_once_with(
+            "admin@example.com",
+            "user_deleted",
+            {"email": "envonly@example.com"},
         )
 
     def test_admin_users_delete_missing_user_does_not_log(self):
@@ -727,6 +766,28 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         log_mock.assert_not_called()
+
+    def test_admin_users_delete_missing_user_skips_storage_write(self):
+        # delete_user_role writes a tombstone unconditionally so an env-based
+        # role can't silently restore access on the next login. Handy for a
+        # real user; harmful for a typo — a random email typed into the form
+        # otherwise pollutes user_roles storage with a permanent "revoked"
+        # entry for someone who was never a user in the first place. The
+        # route must skip the call when target_role == "guest".
+        self.login_as("admin", email="admin@example.com")
+        with patch.object(self.services.storage, "delete_user_role") as delete_mock, patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ):
+            response = self.client.post(
+                "/admin/users",
+                data={"email": "ghost@example.com", "action": "delete"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"User not found.", response.data)
+        delete_mock.assert_not_called()
 
     def test_admin_users_role_change_rejected_for_peer_does_not_log(self):
         # A standard admin attempting to assign another admin role must be
@@ -911,6 +972,76 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"valid email is required", response.data)
         set_user_role_mock.assert_not_called()
+
+    def test_admin_dashboard_delete_env_configured_user_writes_audit_log(self):
+        # Mirror of test_admin_users_delete_env_configured_user_writes_audit_log
+        # for the combined admin dashboard's delete action. An env-only user
+        # (not in user_roles.json but resolved via the ADMIN_USERS /
+        # AUTHORIZED_USERS env vars) has to be deactivatable through this
+        # form too: the tombstone delete_user_role writes is what blocks the
+        # env fallback from restoring their role. Before this fix the route
+        # keyed off delete_user_role's boolean, which is False for env-only
+        # users because there's no prior FILE entry — so the admin saw
+        # "User not found.", the audit log was skipped, and yet the user
+        # WAS actually deactivated.
+        self.login_as("high_admin", email="owner@example.com")
+        with patch.object(
+            self.services.analytics,
+            "dashboard_data",
+            return_value=({"visits": 10}, {"labels": []}),
+        ), patch.object(
+            self.services.storage,
+            "delete_user_role",
+            return_value=False,
+        ) as delete_mock, patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ), patch.object(
+            self.services.auth,
+            "get_user_role",
+            return_value="admin",  # env-configured role
+        ), patch.object(self.services.notifications, "log_site_change") as log_mock:
+            response = self.client.post(
+                "/admin/dashboard",
+                data={"action": "delete", "email": "envonly@example.com"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Deactivated", response.data)
+        delete_mock.assert_called_once_with("envonly@example.com")
+        log_mock.assert_called_once_with(
+            "owner@example.com",
+            "user_deleted",
+            {"email": "envonly@example.com"},
+        )
+
+    def test_admin_dashboard_delete_missing_user_skips_storage_write(self):
+        # Mirror of test_admin_users_delete_missing_user_skips_storage_write.
+        # delete_user_role writes a tombstone unconditionally; the route must
+        # skip it entirely for a random typo so we don't accumulate permanent
+        # "revoked" entries in user_roles for emails that were never users.
+        self.login_as("high_admin", email="owner@example.com")
+        with patch.object(
+            self.services.analytics,
+            "dashboard_data",
+            return_value=({"visits": 10}, {"labels": []}),
+        ), patch.object(
+            self.services.storage,
+            "delete_user_role",
+        ) as delete_mock, patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ):
+            response = self.client.post(
+                "/admin/dashboard",
+                data={"action": "delete", "email": "ghost@example.com"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"User not found.", response.data)
+        delete_mock.assert_not_called()
 
     def test_admin_dashboard_rejects_malformed_email_on_update(self):
         # Defense in depth for the ``update`` action: without this guard, a


### PR DESCRIPTION
## Summary

Two related bugs in the admin delete flow, both rooted in the fact that `FileStorage`/`SqlStorage.delete_user_role` writes a `"revoked"` tombstone unconditionally (that tombstone is what blocks env-var fallbacks in `AuthService.get_user_role` from silently restoring a deleted user's access on the next login), while returning a bool that only reports whether a previous **file** entry existed:

1. **Silent env-user deletion.** Deleting an env-only user (in `ADMIN_USERS` / `AUTHORIZED_USERS` but with no `user_roles.json` entry) silently succeeded via tombstone, but the admin saw `"User not found."` and the `user_deleted` audit log entry was skipped — despite the user actually being deactivated. No record for compliance/incident review, and no confirmation to the admin that the action took effect.

2. **Random-email storage pollution.** Deleting a typo'd email (no file entry, no env role) also wrote a permanent `"revoked"` tombstone for someone who was never a user in the first place, accumulating cruft in `user_roles` storage over time. Reproduced with a quick REPL:

   ```
   before: False
   delete result: False
   after: { "random@nobody.com": "revoked" }
   ```

## Fix

Gate delete at the route boundary on the env+file-merged `target_role` rather than the storage call's return value, in both `admin_users` and `admin_dashboard_combined`:

- `target_role == "guest"` → no access to remove; show `"User not found."` and skip storage entirely (no tombstone written).
- `target_role != "guest"` → delete unconditionally, show `"Deactivated"`, write the `user_deleted` audit entry. Covers file-only and env-only users correctly.

Storage semantics are unchanged (the unconditional tombstone is still what actually blocks env-var fallbacks); the fix is purely a caller-side guard.

## Tests

- 4 new tests covering the two bug scenarios in both routes.
- 2 existing coverage tests updated to seed the target user so the new existence gate passes (their assertions — `Deactivated` message, audit log fired — were already correct).
- Total: 858 → 862 tests.

## Test plan

- [x] `python -m unittest discover` — 862 tests pass locally
- [x] `ruff check .` — clean
- [x] End-to-end REPL check: env-user delete now shows `Deactivated` and writes the tombstone; random-email delete no longer creates the roles file at all

---
_Generated by [Claude Code](https://claude.ai/code/session_013ns1sgB4amu5rot3Kg48Gh)_