### PR TITLE
Fix whitespace-only blurb/name shadowing in property meta snippet

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -126,11 +126,21 @@ def _property_meta_description(prop: dict) -> str:
     structured facts. Both paths are capped at ~158 chars — the length Google
     typically shows before truncating in search results.
     """
-    blurb = (prop.get("blurb") or prop.get("description") or "").strip()
+    # Strip each candidate before choosing so a whitespace-only ``blurb``
+    # doesn't shadow a real ``description``: the previous ``blurb or
+    # description`` short-circuited on a truthy "   " and then ``.strip()``
+    # collapsed it to "", losing the description entirely and falling all
+    # the way through to the generic fact fallback.
+    blurb = (prop.get("blurb") or "").strip() or (prop.get("description") or "").strip()
     if blurb:
         return _truncate_meta_description(" ".join(blurb.split()))
 
-    name = (prop.get("name") or "Rental home").strip()
+    # ``or "Rental home"`` after ``.strip()`` for the same reason: a
+    # whitespace-only ``name`` is truthy pre-strip, so
+    # ``(prop.get("name") or "Rental home").strip()`` returned "" and the
+    # snippet rendered a leading " — 3 bed, 2 bath, …" with no listing
+    # name at all.
+    name = (prop.get("name") or "").strip() or "Rental home"
     bits = []
     beds, baths = prop.get("bedrooms"), prop.get("bathrooms")
     if beds not in (None, "", "N/A"):

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -2287,6 +2287,48 @@ class PropertyMetaDescriptionTestCase(unittest.TestCase):
         self.assertNotIn("N/A", desc)
         self.assertNotIn(" in .", desc)
 
+    def test_whitespace_only_blurb_falls_back_to_description(self):
+        # A whitespace-only ``blurb`` is truthy, so the previous
+        # ``prop.get("blurb") or prop.get("description")`` short-circuited on
+        # it and never consulted a real ``description`` — the snippet ended up
+        # dropping into the generic fact fallback and silently discarded the
+        # only human-written copy on the listing. Prefer the first
+        # AFTER-STRIP candidate so real content wins over blank input.
+        desc, _ = self._describe(
+            blurb="   \n\t  ",
+            description="Real description of the home.",
+        )
+        self.assertEqual(desc, "Real description of the home.")
+
+    def test_whitespace_only_name_uses_default_in_fact_fallback(self):
+        # A whitespace-only ``name`` used to strip to "" AFTER the ``or
+        # "Rental home"`` fallback ran, so the snippet came back as the
+        # visibly broken " — 3 bed, 2 bath, $1500/mo in 123 Main St. …"
+        # (leading space, no listing name). The default must apply after
+        # strip so any blank shape lands on the fallback.
+        desc, _ = self._describe(
+            name="   ",
+            bedrooms="3",
+            bathrooms="2",
+            rent="1500",
+            address="123 Main St",
+        )
+        self.assertTrue(desc.startswith("Rental home"))
+        self.assertNotIn(" — 3 bed", desc[:5])
+
+    def test_whitespace_only_blurb_and_description_uses_fact_fallback(self):
+        # Both fields whitespace-only should behave the same as both fields
+        # missing — fall through to the fact-based snippet rather than
+        # returning an empty string.
+        desc, _ = self._describe(
+            blurb="   ",
+            description="\n\t  ",
+            name="Maple House",
+            bedrooms="2",
+        )
+        self.assertTrue(desc.startswith("Maple House"))
+        self.assertIn("2 bed", desc)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Two closely-related bugs in `_property_meta_description` (`somewheria_app/routes/public_routes.py`) produced visibly broken search snippets when upstream returned whitespace-only values for the `blurb` or `name` fields.

### Bug 1 — whitespace-only `blurb` shadowed a real `description`

```python
blurb = (prop.get("blurb") or prop.get("description") or "").strip()
```

`"   " or "Real description"` short-circuits on the truthy whitespace and never consults `description`. Then `.strip()` collapses it to `""`, `if blurb:` is False, and the code falls all the way through to the generic fact-based fallback — silently discarding the only human-written copy on the listing.

### Bug 2 — whitespace-only `name` broke the fact fallback

```python
name = (prop.get("name") or "Rental home").strip()
```

`("   " or "Rental home").strip()` returns `""` — the default only fires when `.get("name")` is None/empty, not when it's blank whitespace. The fact fallback then rendered as:

```
 — 3 bed, 2 bath, $1500/mo in 123 Main St. Available to rent from Somewheria, LLC. …
```

Leading space, em-dash, no listing name.

### Fix

Strip each candidate before choosing / defaulting so blank shapes fall through to the next real value:

```python
blurb = (prop.get("blurb") or "").strip() or (prop.get("description") or "").strip()
...
name = (prop.get("name") or "").strip() or "Rental home"
```

## Test plan

- [x] `test_whitespace_only_blurb_falls_back_to_description` — whitespace blurb + real description → returns the description.
- [x] `test_whitespace_only_name_uses_default_in_fact_fallback` — whitespace name → snippet starts with "Rental home".
- [x] `test_whitespace_only_blurb_and_description_uses_fact_fallback` — both fields blank → fact fallback with real name/beds.
- [x] All 12 existing `PropertyMetaDescriptionTestCase` tests still pass.
- [x] Full suite: 861 tests pass (up from 858), 1 skipped.
- [x] `ruff check .` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012P5WrAfX4tjEQbGQU4r2MM)_