### PR TITLE
Quiet routine AppointmentService bookkeeping in the logs

### DIFF
--- a/somewheria_app/services/appointments.py
+++ b/somewheria_app/services/appointments.py
@@ -22,10 +22,17 @@ class AppointmentService:
 
     def load(self) -> dict[str, set[str]]:
         appointments: dict[str, set[str]] = {}
-        abs_path = self.config.property_appointments_file.resolve()
-        self.logger.info("Loading appointments from %s", abs_path)
+        # ``/property/<uuid>`` calls load() on every page view, so a routine
+        # read must not spam INFO — the operator's terminal / systemd journal
+        # would fill with per-request "Loading appointments" lines. DEBUG
+        # keeps the trace available when it's actually being investigated
+        # without drowning production output.
+        self.logger.debug("Loading appointments from %s", self.config.property_appointments_file)
         if not self.config.property_appointments_file.exists():
-            self.logger.info("Appointments file does not exist yet: %s", abs_path)
+            self.logger.debug(
+                "Appointments file does not exist yet: %s",
+                self.config.property_appointments_file,
+            )
             return appointments
         with self._lock:
             with self.config.property_appointments_file.open("r", encoding="utf-8") as handle:
@@ -45,8 +52,10 @@ class AppointmentService:
         # then os.replace() over the destination. A crash mid-write leaves the
         # original file intact instead of a half-written, truncated one.
         path = self.config.property_appointments_file
-        abs_path = path.resolve()
-        self.logger.info("Saving %s appointment sets to %s", len(appointments), abs_path)
+        # Booking is a per-visitor operation and every call ends up here.
+        # DEBUG for the routine "wrote N sets" trace matches how the rest of
+        # the storage layer logs (only errors surface at INFO/WARNING).
+        self.logger.debug("Saving %s appointment sets to %s", len(appointments), path)
         with self._lock:
             path.parent.mkdir(parents=True, exist_ok=True)
             fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
@@ -64,7 +73,10 @@ class AppointmentService:
                 except OSError:
                     pass
                 raise
-        self.print_check_file(self.config.property_appointments_file, "Appointments saved")
+        # No post-write existence probe: if os.replace() didn't raise, the
+        # file is present. print_check_file() here just emitted another INFO
+        # line per booking with no diagnostic value beyond the startup health
+        # check that already runs from website_app.py.
 
     def book(self, property_id: str, iso_date: str) -> bool:
         # Returns True when the booking was newly recorded, False when the

--- a/test_services.py
+++ b/test_services.py
@@ -569,6 +569,32 @@ class AppointmentServiceTestCase(unittest.TestCase):
         self.assertEqual(loaded["prop-1"], {"2030-05-01", "2030-05-02"})
         self.assertEqual(loaded["prop-2"], {"2030-05-01"})
 
+    def test_load_does_not_emit_info_for_routine_reads(self):
+        """/property/<uuid> calls load() on every page view; routine reads
+        must stay at DEBUG so a busy public site doesn't flood the operator's
+        journal with per-request bookkeeping lines."""
+        with patch.object(self.service.logger, "info") as info_mock:
+            self.service.load()
+        info_mock.assert_not_called()
+
+    def test_save_does_not_emit_info_for_routine_writes(self):
+        """Every appointment booking triggers save(); those routine writes
+        should not surface at INFO. Only errors need operator attention —
+        matches how FileStorageService logs storage traffic."""
+        with patch.object(self.service.logger, "info") as info_mock:
+            self.service.save({"prop-1": {"2030-05-01"}})
+        info_mock.assert_not_called()
+
+    def test_save_skips_the_redundant_post_write_existence_probe(self):
+        """After os.replace() returns, the file exists — probing it again
+        just emitted a duplicate diagnostic line per booking. print_check_file
+        should only be called from the startup health check, not the write
+        path, so a repeated save() cannot spam the log with 'Appointments
+        saved: ... (exists)' rows."""
+        with patch.object(self.service, "print_check_file") as probe_mock:
+            self.service.save({"prop-1": {"2030-05-01"}})
+        probe_mock.assert_not_called()
+
 
 class PropertyServiceTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Every `/property/<uuid>` page view calls `AppointmentService.load()`, and every viewing request calls `save()`. Both were emitting INFO-level lines per call, plus a post-save existence probe from `print_check_file()`. On a busy public site — where crawlers alone hit dozens of property pages a minute — that flooded the operator's terminal / systemd journal with routine bookkeeping that has no diagnostic value.

- `load()` now logs at DEBUG for the "reading from …" and "not created yet" traces.
- `save()` logs the "wrote N sets" line at DEBUG, matching how the rest of the storage layer treats routine writes (only errors surface at INFO/WARNING).
- Removed the trailing `print_check_file()` from `save()` — if `os.replace()` didn't raise, the file exists. The startup health check in `website_app.py` still calls `print_check_file` once at boot, which is the only place the diagnostic actually helps.

No behavior change beyond log verbosity; return values and atomic-write semantics are unchanged.

## Test plan

- [x] Three new tests in `test_services.AppointmentServiceTestCase` lock in the new contract:
  - `test_load_does_not_emit_info_for_routine_reads`
  - `test_save_does_not_emit_info_for_routine_writes`
  - `test_save_skips_the_redundant_post_write_existence_probe`
- [x] Full suite: `python -m unittest discover` → 861 passing (858 → 861), 1 skipped.
- [x] `ruff check` clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkMCpsHdALXezza8rcZd4a)_