### PR TITLE
Skip user_roles writes when the delete target has no effective role

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -491,17 +491,29 @@ def admin_dashboard_combined():
             error = "You cannot modify your own account here."
         elif action == "delete":
             target_role = services.auth.get_user_role(email)
-            if not _can_act_on(actor_role, target_role):
+            # A "guest" target has no role in file OR env — there's nothing to
+            # revoke. Short-circuit before touching storage so a typo email
+            # doesn't leave a permanent ``{email: "revoked"}`` tombstone
+            # cluttering user_roles.json (the previous flow always wrote the
+            # tombstone and then reported "User not found").
+            if target_role == "guest":
+                error = "User not found."
+            elif not _can_act_on(actor_role, target_role):
                 error = "You cannot modify a user at or above your own role."
-            elif services.storage.delete_user_role(email):
+            else:
+                # Always emit the tombstone: for an env-configured admin with
+                # no file entry, ``delete_user_role`` returns False (nothing
+                # was previously stored), but the tombstone it writes is
+                # exactly what stops the .env fallback from restoring access
+                # on the next login. Use ``target_role`` — not the return
+                # value — to decide whether the delete was meaningful.
+                services.storage.delete_user_role(email)
                 success = (
                     f"Deactivated {email} — their access is revoked, but their "
                     "contracts, profile, and tickets are kept. Re-add the email "
                     "to restore access."
                 )
                 services.notifications.log_site_change(actor_email, "user_deleted", {"email": email})
-            else:
-                error = "User not found."
         elif action == "update":
             new_role = request.form.get("role", "").strip()
             target_role = services.auth.get_user_role(email)
@@ -695,9 +707,21 @@ def admin_users():
         elif email == actor_email:
             error = "You cannot modify your own account here."
         elif action == "delete":
-            if not _can_act_on(actor_role, target_role):
+            # Same short-circuit as /admin/dashboard: a "guest" target has
+            # no role anywhere, so writing a tombstone would only pollute
+            # user_roles storage with a permanent entry for an address that
+            # no one can ever log in as. Skip the storage call and report
+            # the miss.
+            if target_role == "guest":
+                error = "User not found."
+            elif not _can_act_on(actor_role, target_role):
                 error = "You cannot modify a user at or above your own role."
-            elif services.storage.delete_user_role(email):
+            else:
+                # Always issue the tombstone: for an env-only admin
+                # ``delete_user_role`` returns False (nothing was previously
+                # stored), but the tombstone it writes is exactly what stops
+                # the .env fallback from restoring access on the next login.
+                services.storage.delete_user_role(email)
                 success = (
                     f"Deactivated {email} — their access is revoked, but their "
                     "contracts, profile, and tickets are kept. Re-add the email "
@@ -711,8 +735,6 @@ def admin_users():
                 services.notifications.log_site_change(
                     actor_email, "user_deleted", {"email": email}
                 )
-            else:
-                error = "User not found."
         elif new_role in ALLOWED_ROLES:
             # Defense in depth: reject malformed emails before they touch
             # user_roles storage. Delete is intentionally exempt so an admin

--- a/test_coverage_full.py
+++ b/test_coverage_full.py
@@ -1675,11 +1675,15 @@ class CoverageRouteBranchTestCase(unittest.TestCase):
 
     def test_admin_dashboard_handles_branchy_post_paths(self):
         self.login_as("high_admin", email="owner@example.com")
+        # The delete branch decides success from the caller's *effective* role
+        # (via auth.get_user_role), not from delete_user_role's return value,
+        # so the delete_ok path needs an existing storage entry to be visible
+        # and the delete_missing path needs the target to resolve to guest.
         with patch.object(self.services.analytics, "dashboard_data", return_value=({}, {})), patch.object(
             self.services.storage,
             "get_user_roles",
-            return_value={"existing@example.com": "admin"},
-        ), patch.object(self.services.storage, "delete_user_role", side_effect=[True, False]), patch.object(
+            return_value={"existing@example.com": "admin", "user@example.com": "renter"},
+        ), patch.object(self.services.storage, "delete_user_role", return_value=True), patch.object(
             self.services.storage,
             "set_user_role",
         ) as set_role_mock, patch.object(self.services.notifications, "log_site_change") as change_mock:
@@ -1732,10 +1736,13 @@ class CoverageRouteBranchTestCase(unittest.TestCase):
 
     def test_admin_users_delete_success_and_invalid_role(self):
         self.login_as("admin")
+        # target_role must resolve to something above "guest" for the delete
+        # branch to reach storage — the route short-circuits guest targets to
+        # "User not found." without touching user_roles.
         with patch.object(self.services.storage, "delete_user_role", return_value=True), patch.object(
             self.services.storage,
             "get_user_roles",
-            side_effect=[{}, {}, {}],
+            side_effect=[{"user@example.com": "renter"}, {"user@example.com": "renter"}, {"user@example.com": "renter"}],
         ):
             delete_response = self.client.post(
                 "/admin/users",

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -694,7 +694,7 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         with patch.object(self.services.storage, "delete_user_role", return_value=True), patch.object(
             self.services.storage,
             "get_user_roles",
-            return_value={},
+            return_value={"renter@example.com": "renter"},
         ), patch.object(self.services.notifications, "log_site_change") as log_mock:
             response = self.client.post(
                 "/admin/users",
@@ -708,6 +708,59 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
             "user_deleted",
             {"email": "renter@example.com"},
         )
+
+    def test_admin_users_delete_env_only_admin_reports_success(self):
+        # An admin configured purely through the ADMIN_USERS env var — no file
+        # entry yet — used to hit ``delete_user_role``, get False back (nothing
+        # to remove), and the route showed "User not found." even though the
+        # tombstone WAS written and the user could no longer log in. Route now
+        # uses the effective role (via auth.get_user_role) to decide success,
+        # so the UX matches what the storage actually did.
+        self.login_as("high_admin", email="owner@example.com")
+        with patch.object(self.services.storage, "delete_user_role", return_value=False) as delete_mock, patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ), patch.object(
+            self.services.auth,
+            "get_user_role",
+            return_value="admin",
+        ), patch.object(self.services.notifications, "log_site_change") as log_mock:
+            response = self.client.post(
+                "/admin/users",
+                data={"email": "envadmin@example.com", "action": "delete"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Deactivated", response.data)
+        delete_mock.assert_called_once_with("envadmin@example.com")
+        log_mock.assert_called_once_with(
+            "owner@example.com",
+            "user_deleted",
+            {"email": "envadmin@example.com"},
+        )
+
+    def test_admin_users_delete_unknown_email_does_not_touch_storage(self):
+        # A delete for an address with no role in the file OR the env used to
+        # write a permanent {email: "revoked"} tombstone to user_roles storage
+        # anyway — a slow leak where every typo permanently bloated the file.
+        # Route now short-circuits on target_role == "guest" so nothing lands
+        # in storage.
+        self.login_as("admin", email="admin@example.com")
+        with patch.object(self.services.storage, "delete_user_role") as delete_mock, patch.object(
+            self.services.storage,
+            "get_user_roles",
+            return_value={},
+        ), patch.object(self.services.notifications, "log_site_change") as log_mock:
+            response = self.client.post(
+                "/admin/users",
+                data={"email": "typo@example.com", "action": "delete"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"User not found.", response.data)
+        delete_mock.assert_not_called()
+        log_mock.assert_not_called()
 
     def test_admin_users_delete_missing_user_does_not_log(self):
         # A delete that hits a non-existent email leaves storage untouched, so


### PR DESCRIPTION
## Summary

Two related fixes to the `/admin/users` and `/admin/dashboard` delete branches, both rooted in the same conflation: the routes were using `storage.delete_user_role`'s return value to decide UX, and the storage layer was unconditionally stamping a `"revoked"` tombstone regardless of whether there was anything to revoke.

**Bug 1 — storage pollution on typos.** A delete for an address with no role in `user_roles.json` *or* the `AUTHORIZED_USERS` / `ADMIN_USERS` / `HIGH_ADMIN_USERS` env lists still wrote a permanent `{email: "revoked"}` row before returning False. Every admin typo/paste-error left a permanent tombstone for an account nobody could ever log in as. Verified in a quick repro against `FileStorageService.delete_user_role`.

**Bug 2 — mis-reported delete for env-configured admins.** An admin whose only role source was `ADMIN_USERS` (no file entry) had `delete_user_role` return False — nothing was previously stored — but the tombstone it wrote was exactly what stopped the `.env` fallback from restoring access on next login. The UI showed "User not found." even though the delete had taken effect. The audit-log line was also skipped in that case.

**Fix.** Both routes now consult the effective role via `auth.get_user_role` (which reads file + env) before touching storage:

- `target_role == "guest"` → storage untouched, "User not found." reported. No spurious tombstone.
- Otherwise → tombstone written and success reported, whether or not a prior file entry existed. Audit trail fires either way.

## Changes

- `somewheria_app/routes/admin_routes.py` — reorder the delete branches in `admin_users` and `admin_dashboard_combined` so a guest target short-circuits before storage is touched, and success is decided from `target_role` instead of `delete_user_role`'s return value.
- `test_routes_expanded.py` — two new tests: env-only admin delete reports success and writes the audit log; unknown-email delete does not touch storage or the audit log. One existing test (`test_admin_users_delete_writes_audit_log`) updated to seed `get_user_roles` so the target resolves above guest.
- `test_coverage_full.py` — two existing tests updated for the same reason (`test_admin_dashboard_handles_branchy_post_paths`, `test_admin_users_delete_success_and_invalid_role`). No coverage was weakened; both still assert the same user-facing messages and audit-log calls.

## Test plan

- [x] `python -m unittest discover` → 860 passed, 1 skipped (up from 858 pre-change).
- [x] `python -m unittest test_routes_expanded test_coverage_full test_services test_sql_storage` → 452 passed.
- [x] Manual `FileStorageService.delete_user_role` repro: before the fix, `delete_user_role("never-existed@example.com")` on an empty file returned False *and* wrote `{"never-existed@example.com": "revoked"}`. After the fix, the route no longer calls into storage in that scenario.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSDhbTnarp4CGLia6NRqCP)_