### PR TITLE
Restore CI on main: fix path-shim missing-attribute test

### DIFF
--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,10 +288,13 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
+        # DID configure correctly.
+        #
+        # ``_make_config`` populates every known file attribute so the rest
+        # of the suite exercises the routing table end-to-end; strip one
+        # here to simulate the "older config, newer sql_storage" mismatch
+        # this test is pinning.
+        delattr(self.config, "hidden_listings_file")
         self.assertFalse(hasattr(self.config, "hidden_listings_file"))
         self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])


### PR DESCRIPTION
## Summary

CI on `main` has been red across every merge since PR #94 landed the regression test `test_missing_config_attribute_is_treated_as_unknown_path` in `test_sql_storage.py`. Every workflow run against `main` from PR #96 through PR #100 shows the same failure:

```
FAIL: test_missing_config_attribute_is_treated_as_unknown_path
AssertionError: True is not false
```

### Root cause

The two changes were authored against different fixture snapshots and merged in an order that left the assertion permanently failing:

- Commit `bd1d1a3` ("Restore CI: extend SqlStorage test fixture to hidden_listings_file") added `hidden_listings_file` to `_make_config` so the SqlStorage path-shim tests could reach the routing table for hidden listings.
- Commit `41efab1` (PR #94) later added a regression test that asserts the fixture **does not** have `hidden_listings_file`, to pin the "config forgot an attribute, don't AttributeError" behavior — but the fixture had already been changed, so the very first assertion in the new test fails.

### Fix

Keep the fixture intact for the rest of the suite (which needs `hidden_listings_file`) and satisfy the missing-attribute test's own intent by `delattr`-ing the field inline — simulating the "older AppConfig against newer sql_storage" mismatch it exists to pin. The `SqlStorageService._path_key` tolerance for missing attributes is still exercised exactly as PR #94 intended.

## Test plan

- [x] `python -m unittest test_sql_storage.PathShimUnknownPathTestCase` — 3/3 pass
- [x] `python -m unittest discover` — 881/881 pass (1 skipped)
- [x] `ruff check .` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01VCGjrZWWexcCs8eK6LEiZj)_