### PR TITLE
Restore green CI: fix broken PathShim regression assertion

### DIFF
--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,17 +288,31 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
-        self.assertFalse(hasattr(self.config, "hidden_listings_file"))
-        self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
-        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
-        # A path that IS configured must still route correctly.
-        self.storage.set_user_role("still-works@example.com", "renter")
+        # DID configure correctly.
+        #
+        # Build a bespoke config that omits ``hidden_listings_file`` on
+        # purpose (the shared ``_make_config`` sets every attribute so
+        # HiddenListingsTestCase can round-trip through the shim; we can't
+        # rely on that fixture to exercise the missing-attribute branch).
+        partial_config = SimpleNamespace(
+            registration_file=self.base / "pending_registrations.json",
+            user_roles_file=self.base / "user_roles.json",
+            renter_profile_file=self.base / "renter_profiles.json",
+            contracts_file=self.base / "renter_contracts.json",
+            tickets_file=self.base / "tickets.json",
+            lead_capture_file=self.base / "pending_lead_captures.json",
+            sqlite_file=self.base / "partial.sqlite3",
+        )
+        self.assertFalse(hasattr(partial_config, "hidden_listings_file"))
+        partial_storage = SqlStorageService(partial_config)
         self.assertEqual(
-            self.storage.get_user_roles(),
+            partial_storage.load_json_file(self.base / "unknown.json", []), []
+        )
+        partial_storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+        # A path that IS configured must still route correctly.
+        partial_storage.set_user_role("still-works@example.com", "renter")
+        self.assertEqual(
+            partial_storage.get_user_roles(),
             {"still-works@example.com": "renter"},
         )
 


### PR DESCRIPTION
## Summary

CI has been red on `main` since bab1219 (2026-07-29), through every subsequent push. The failing test is `test_sql_storage.PathShimUnknownPathTestCase.test_missing_config_attribute_is_treated_as_unknown_path`.

Two PRs landed the same day and produced a logical conflict git couldn't detect:

- **PR #94** (41efab1) added a regression test that asserts the shared config fixture does *not* set `hidden_listings_file`, so it can exercise `_path_key`'s missing-attribute branch.
- **PR #93** (bd1d1a3) added `hidden_listings_file` to that same shared fixture so the new `HiddenListingsTestCase` could round-trip it through the path shim.

They edited different lines, so the merge was clean — but the new regression test now fails immediately: the fixture does have the attribute the test insists is missing.

## Fix

Give `test_missing_config_attribute_is_treated_as_unknown_path` its own `SimpleNamespace` that intentionally omits `hidden_listings_file`, with its own `SqlStorageService` bound to it. Both goals are satisfied:
- `HiddenListingsTestCase` still gets the full fixture it needs.
- The missing-attribute branch of `_path_key` is still exercised end-to-end.

No production code was changed.

## Test plan

- [x] `python -m unittest test_sql_storage.PathShimUnknownPathTestCase` — 3/3 pass.
- [x] `python -m unittest discover` — 881 pass, 1 skipped, 0 failures (~150s).
- [x] `ruff check .` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ksQSUb66jfra1AjwrvE5k)_