### PR TITLE
Restore green CI and harden admin_registrations email validation

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -657,6 +657,19 @@ def admin_registrations():
                 title="Pending Registrations",
                 error="No email provided.",
             )
+        # Reject malformed emails at the admin boundary, matching admin_users
+        # add/update. The /register form already validates via is_valid_email,
+        # so a garbage email here means either a hand-crafted POST or a stale
+        # pending row from before the form-side validation landed — writing
+        # "renter" for it into user_roles.json produces a ghost account that
+        # never matches a real OAuth login and pollutes the roster forever.
+        if not is_valid_email(email):
+            return render_template(
+                "admin_registrations.html",
+                pending=pending,
+                title="Pending Registrations",
+                error="A valid email is required.",
+            )
         if action == "approve":
             # Only write a file role when it's an upgrade. A file entry wins
             # over the .env lists in get_user_role, so blindly writing

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -547,6 +547,30 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         remove_pending_mock.assert_not_called()
         send_email_mock.assert_not_called()
 
+    def test_admin_registrations_rejects_invalid_email_on_post(self):
+        # A hand-crafted approve/reject POST with a malformed email must NOT
+        # write to user_roles or fire an email — the /register form validates
+        # with is_valid_email, and this admin-side guard mirrors admin_users
+        # add/update so a garbage POST can't slip a ghost account into the
+        # roster.
+        self.login_as("admin")
+        with patch.object(self.services.storage, "get_pending_registrations", return_value=[]), patch.object(
+            self.services.storage,
+            "set_user_role",
+        ) as set_role_mock, patch.object(self.services.storage, "remove_pending_registration") as remove_pending_mock, patch.object(
+            self.services.notifications,
+            "send_email",
+        ) as send_email_mock:
+            response = self.client.post(
+                "/admin/registrations",
+                data={"action": "approve", "email": "not-an-email"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        set_role_mock.assert_not_called()
+        remove_pending_mock.assert_not_called()
+        send_email_mock.assert_not_called()
+
     def test_admin_registrations_rejects_invalid_action(self):
         self.login_as("admin")
         with patch.object(

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,17 +288,31 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
-        self.assertFalse(hasattr(self.config, "hidden_listings_file"))
-        self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
-        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
-        # A path that IS configured must still route correctly.
-        self.storage.set_user_role("still-works@example.com", "renter")
+        # DID configure correctly.
+        #
+        # Build a bespoke config that omits ``hidden_listings_file`` on
+        # purpose. The shared ``_make_config`` sets every attribute so
+        # HiddenListingsTestCase can round-trip through the shim; we can't
+        # rely on that fixture to exercise the missing-attribute branch.
+        partial_config = SimpleNamespace(
+            registration_file=self.base / "pending_registrations.json",
+            user_roles_file=self.base / "user_roles.json",
+            renter_profile_file=self.base / "renter_profiles.json",
+            contracts_file=self.base / "renter_contracts.json",
+            tickets_file=self.base / "tickets.json",
+            lead_capture_file=self.base / "pending_lead_captures.json",
+            sqlite_file=self.base / "partial.sqlite3",
+        )
+        self.assertFalse(hasattr(partial_config, "hidden_listings_file"))
+        partial_storage = SqlStorageService(partial_config)
         self.assertEqual(
-            self.storage.get_user_roles(),
+            partial_storage.load_json_file(self.base / "unknown.json", []), []
+        )
+        partial_storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+        # A path that IS configured must still route correctly.
+        partial_storage.set_user_role("still-works@example.com", "renter")
+        self.assertEqual(
+            partial_storage.get_user_roles(),
             {"still-works@example.com": "renter"},
         )
 


### PR DESCRIPTION
## Summary

Two small backend fixes bundled — the CI fix is a prerequisite because CI has been red on `main` since 2026-07-29 (bab1219), so any new PR needs the test fix included to prove itself.

### 1. Fix broken PathShim regression assertion

Two PRs that landed the same day produced a logical conflict git couldn't detect:

- **PR #94** (`41efab1`) added `test_missing_config_attribute_is_treated_as_unknown_path` in `test_sql_storage.py`, asserting the shared config fixture does **not** set `hidden_listings_file`.
- **PR #93** (`bd1d1a3`) added `hidden_listings_file` to that same shared fixture so the new `HiddenListingsTestCase` could round-trip it through the path shim.

Different lines, clean merge, but the regression test fails immediately. Every push to `main` since has failed the Unit tests job.

The regression now gets its own `SimpleNamespace` that intentionally omits `hidden_listings_file`, so:

- `HiddenListingsTestCase` still has the attribute it needs.
- `_path_key`'s missing-attribute branch is still exercised end-to-end.

(Same fix as the still-open PR #116; included here because without it my other change can't verify itself.)

### 2. Reject malformed emails at the `admin_registrations` boundary

Mirrors the `is_valid_email` gate PR #110 added on `admin_users` add/update.

The public `/register` form validates via `is_valid_email`, but the admin approve/reject endpoint didn't — so a hand-crafted admin POST or a stale pending row from before the form-side validation landed could still smuggle a garbage email through. The follow-up code paths silently:

- Write `"renter"` for that garbage key into `user_roles.json` — a ghost account that never matches a real OAuth login, but pollutes the roster forever.
- Fire an email that `NotificationService.send_email`'s own `is_valid_email` gate silently drops, so the operator sees no error.

Rejecting at the admin boundary is the same defense-in-depth pattern PR #110 established.

## Test plan

- [x] `python -m unittest discover` — 882 tests pass (was 881 before the new regression test).
- [x] `ruff check .` — clean.
- [x] New test `test_admin_registrations_rejects_invalid_email_on_post` locks in the new behavior.
- [x] Existing `admin_registrations` approve/reject tests (which use `pending@example.com`) still pass — new gate accepts valid emails as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_018SZs3maECQn5z22LzupKcr)_