### PR TITLE
Restore CI on main and harden null-email handling in FileStorageService

### DIFF
--- a/somewheria_app/services/storage.py
+++ b/somewheria_app/services/storage.py
@@ -112,9 +112,15 @@ class FileStorageService:
             return True
 
     def remove_pending_registration(self, email: str) -> None:
+        target = email.lower()
         with self.file_lock:
+            # ``or ""`` so a legacy row persisted with ``email: null`` (which
+            # ``add_pending_registration`` now rejects but earlier writes did
+            # not) doesn't blow up ``None.lower()`` and abort the admin's
+            # approve/reject POST inside the file lock.
             registrations = [
-                item for item in self.get_pending_registrations() if item.get("email", "").lower() != email.lower()
+                item for item in self.get_pending_registrations()
+                if (item.get("email") or "").lower() != target
             ]
             self.save_json_file(self.config.registration_file, registrations)
 
@@ -166,17 +172,23 @@ class FileStorageService:
             leads = self.get_pending_lead_captures()
             # De-duplicate by email so a repeated submission doesn't bloat the file
             # or give the requester a way to flood the admin UI.
-            if any(item.get("email", "").lower() == target_email for item in leads):
+            # ``or ""`` guards against legacy rows with a null email field —
+            # ``None.lower()`` would raise inside the file lock and abort the
+            # submission for every subsequent caller until an admin cleaned
+            # the file up.
+            if any((item.get("email") or "").lower() == target_email for item in leads):
                 return False
             leads.append(lead)
             self.save_json_file(self.config.lead_capture_file, leads)
             return True
 
     def remove_pending_lead_capture(self, email: str) -> None:
+        target = email.lower()
         with self.file_lock:
+            # See remove_pending_registration for the ``or ""`` rationale.
             leads = [
                 item for item in self.get_pending_lead_captures()
-                if item.get("email", "").lower() != email.lower()
+                if (item.get("email") or "").lower() != target
             ]
             self.save_json_file(self.config.lead_capture_file, leads)
 

--- a/test_services.py
+++ b/test_services.py
@@ -308,6 +308,64 @@ class FileStorageServiceTestCase(unittest.TestCase):
             [{"email": "keep@example.com"}],
         )
 
+    def test_remove_pending_registration_tolerates_null_email_row(self):
+        # ``add_pending_registration`` now rejects null-email entries, but a
+        # legacy on-disk file (or a hand-edit) can still carry
+        # ``{"email": null}`` rows. ``.get("email", "")`` returns None for
+        # those and the resulting ``None.lower()`` used to crash the admin's
+        # approve/reject POST inside the file lock, blocking every subsequent
+        # writer until the file was cleaned by hand.
+        with patch.object(
+            self.service,
+            "get_pending_registrations",
+            return_value=[
+                {"email": None, "name": "Legacy"},
+                {"email": "drop@example.com"},
+                {"email": "keep@example.com"},
+            ],
+        ), patch.object(self.service, "save_json_file") as save_json_mock:
+            self.service.remove_pending_registration("DROP@example.com")
+
+        save_json_mock.assert_called_once_with(
+            self.config.registration_file,
+            [{"email": None, "name": "Legacy"}, {"email": "keep@example.com"}],
+        )
+
+    def test_remove_pending_lead_capture_tolerates_null_email_row(self):
+        # Mirror of the pending-registration guard for the leads bucket; both
+        # buckets share the same JSON-file shape and the same historical
+        # exposure to null-email rows.
+        with patch.object(
+            self.service,
+            "get_pending_lead_captures",
+            return_value=[
+                {"email": None},
+                {"email": "drop@example.com"},
+                {"email": "keep@example.com"},
+            ],
+        ), patch.object(self.service, "save_json_file") as save_json_mock:
+            self.service.remove_pending_lead_capture("drop@example.com")
+
+        save_json_mock.assert_called_once_with(
+            self.config.lead_capture_file,
+            [{"email": None}, {"email": "keep@example.com"}],
+        )
+
+    def test_add_pending_lead_capture_tolerates_null_email_row_in_dedup(self):
+        # If a legacy row with a null email is already in the list, the
+        # duplicate-check for a new submission must not crash on
+        # ``None.lower()``; otherwise every subsequent lead submission fails
+        # (and the caller sees a 500) until the file is cleaned by hand.
+        with patch.object(
+            self.service,
+            "get_pending_lead_captures",
+            return_value=[{"email": None}, {"email": "existing@example.com"}],
+        ), patch.object(self.service, "save_json_file") as save_json_mock:
+            self.assertTrue(
+                self.service.add_pending_lead_capture({"email": "new@example.com"})
+            )
+        save_json_mock.assert_called_once()
+
     def test_set_user_role_lowercases_email_and_saves(self):
         with patch.object(self.service, "get_user_roles", return_value={}), patch.object(
             self.service,

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,10 +288,11 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
+        # DID configure correctly. ``_make_config`` now sets every attribute
+        # the shim knows about (a prior CI break led to that; see
+        # bd1d1a3), so simulate the "older config" case by removing the
+        # newest attribute after construction.
+        del self.config.hidden_listings_file
         self.assertFalse(hasattr(self.config, "hidden_listings_file"))
         self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])


### PR DESCRIPTION
## Summary

Two independent backend fixes.

### 1. Restore CI on `main`

`test_missing_config_attribute_is_treated_as_unknown_path` (added in
[#94](https://github.com/kltef/Somewheria-LLC-Rental-Property-Website/pull/94), commit `41efab1`) opens with
`assertFalse(hasattr(self.config, "hidden_listings_file"))` and was written against a fixture that did not set that attribute. `bd1d1a3` had already extended `_make_config` to include `hidden_listings_file` (to keep the other `PathShimUnknownPathTestCase` tests reachable). The two changes collided in review, so CI has been red on `main` from PR #93 onward with:

```
AssertionError: True is not false
```

Fix: delete the attribute from `self.config` at the top of the test so it still exercises the "older-config" branch it was written for, without regressing the fixture the other tests rely on.

### 2. Null-email crash in `FileStorageService`

Three call sites in `services/storage.py` compared `item.get("email", "").lower()` against a target email:

- `remove_pending_registration`
- `remove_pending_lead_capture`
- `add_pending_lead_capture` (in the dedup check)

`dict.get("email", "")` returns `None` (not `""`) when the key is present with a null value, so a single legacy row with `{"email": null}` in `pending_registrations.json` or `pending_lead_captures.json` raises `AttributeError` inside the `file_lock` and aborts the admin approve/reject POST — or the lead submission POST — for every subsequent caller until the file is cleaned by hand.

Their `add_pending_registration` sibling and the SQL backend already use the safe `(item.get("email") or "").lower()` pattern; adopting it here restores parity and adds three regression tests that pin the behaviour.

## Test plan

- [x] `python -m unittest discover` — 884 tests pass (3 new)
- [x] `ruff check .` — clean
- [x] `test_sql_storage.PathShimUnknownPathTestCase` now passes with the same fixture
- [x] Full suite runs green with `DISABLE_BACKGROUND_THREADS=1 FLASK_ENV=development SECRET_KEY=ci-only-not-for-prod`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VA1cfiuytrmUwt8yaAXW8c)_