### PR TITLE
Restore CI: fix broken PathShim missing-attribute assertion

### DIFF
--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,17 +288,24 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
-        self.assertFalse(hasattr(self.config, "hidden_listings_file"))
-        self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
-        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
-        # A path that IS configured must still route correctly.
-        self.storage.set_user_role("still-works@example.com", "renter")
+        # DID configure correctly.
+        #
+        # Give this case its own storage so the shared fixture can keep
+        # ``hidden_listings_file`` set for the round-trip cases in
+        # HiddenListingsTestCase, while we still exercise the
+        # missing-attribute branch of ``_path_key`` end-to-end.
+        stripped_config = _make_config(self.base)
+        del stripped_config.hidden_listings_file
+        stripped_storage = SqlStorageService(stripped_config)
+        self.assertFalse(hasattr(stripped_config, "hidden_listings_file"))
         self.assertEqual(
-            self.storage.get_user_roles(),
+            stripped_storage.load_json_file(self.base / "unknown.json", []), []
+        )
+        stripped_storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+        # A path that IS configured must still route correctly.
+        stripped_storage.set_user_role("still-works@example.com", "renter")
+        self.assertEqual(
+            stripped_storage.get_user_roles(),
             {"still-works@example.com": "renter"},
         )
 


### PR DESCRIPTION
## Summary

CI has been red on `main` since bab1219 because `test_missing_config_attribute_is_treated_as_unknown_path` (added in PR #94) asserts the shared SqlStorage test fixture does **not** set `hidden_listings_file` — but PR #93 (bd1d1a3) had already extended `_make_config` to include that attribute so the `HiddenListingsTestCase` cases could round-trip through the path shim. The two PRs touched different lines of the same file, git found no conflict, and the assertion has been failing on every push since.

## Fix

Give the missing-attribute test case its own `SimpleNamespace` fixture (with `hidden_listings_file` `del`'d off) instead of relying on the shared one. This satisfies both goals:

- `HiddenListingsTestCase` still gets the attribute it needs to route via the path shim.
- The missing-attribute branch of `_path_key`'s `getattr(..., None)` fallback is still exercised end-to-end — a `load_json_file` for an unrecognised path returns the default rather than raising `AttributeError`, and a subsequent write to a configured path still routes correctly.

Not weakening the check — the previous assertion was contradicting the fixture and never actually exercised the code path it claimed to. This restores the intended coverage.

## Test plan

- [x] `test_sql_storage.py` passes (33/33), including `test_missing_config_attribute_is_treated_as_unknown_path`
- [x] Full suite passes: `python -m unittest test_services test_routes_expanded test_backup_script test_generated_matrices test_jira_integration test_oauth test_site test_sql_storage test_startup test_coverage_full` → `Ran 881 tests in 165.470s / OK (skipped=1)`
- [x] `ruff check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sga2EhWFwm1WFi4aMFqyU9)_