### PR TITLE
Log contract_download send_file failures; unstick red main CI

### DIFF
--- a/somewheria_app/routes/admin_routes.py
+++ b/somewheria_app/routes/admin_routes.py
@@ -1056,6 +1056,16 @@ def contract_download(contract_id: str):
             download_name=f"contract-{contract_id[:8]}.pdf",
         )
     except Exception:
+        # send_file races with admin delete (unlink between the exists()
+        # check above and Flask's open()), hits permission errors, or
+        # trips over a truncated PDF -- all real infrastructure faults,
+        # not "not found." Log with contract_id + path so admins have a
+        # trail, then keep the 404 fallback so the renter response stays
+        # stable and no partial body is streamed.
+        current_app.logger.exception(
+            "contract_download: send_file failed for %s at %s",
+            contract_id, pdf_path,
+        )
         abort(404)
 
 

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -2058,6 +2058,58 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
             response = self.client.get("/contracts/does-not-exist/download")
         self.assertEqual(response.status_code, 404)
 
+    def test_contract_download_logs_when_send_file_raises_after_exists_check(self):
+        # The contract exists in storage AND its PDF is on disk (the two
+        # existence checks the route runs before touching send_file), but
+        # send_file itself blows up -- a stand-in for the real fault modes:
+        # a race with an admin delete unlinking the PDF between the exists()
+        # check and send_file's open(), a permission problem on the upload
+        # dir, or a truncated PDF. The old handler swallowed those as a
+        # bare abort(404), leaving admins with no log trail. The response
+        # stays 404 (behavior compatible) but the exception must now hit
+        # the app logger so the failure is diagnosable.
+        self.login_as("renter", email="renter@example.com")
+        contract_id = "contract-send-file-boom"
+        upload_dir = self.services.config.contract_upload_dir
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        pdf_path = upload_dir / f"{contract_id}.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4 sample")
+        contracts_data = {
+            "renter@example.com": [
+                {
+                    "id": contract_id,
+                    "property_name": "Maple House",
+                    "start_date": "2024-01-01",
+                    "end_date": "2025-01-01",
+                    "status": "Active",
+                    "pdf_filename": f"{contract_id}.pdf",
+                }
+            ]
+        }
+        try:
+            with patch.object(
+                self.services.storage,
+                "get_renter_contracts",
+                return_value=contracts_data,
+            ), patch(
+                "somewheria_app.routes.admin_routes.send_file",
+                side_effect=PermissionError("simulated I/O failure"),
+            ):
+                with self.assertLogs(self.app.logger, level="ERROR") as log_ctx:
+                    response = self.client.get(
+                        f"/contracts/{contract_id}/download"
+                    )
+            self.assertEqual(response.status_code, 404)
+            joined = "\n".join(log_ctx.output)
+            self.assertIn("contract_download", joined)
+            self.assertIn(contract_id, joined)
+            self.assertIn("PermissionError", joined)
+        finally:
+            try:
+                pdf_path.unlink()
+            except OSError:
+                pass
+
     def test_contract_pdfs_stored_outside_static_tree(self):
         """Regression: contract PDFs must not live under ``static/`` because
         Flask's static handler would serve them at /static/uploads/contracts/...

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,17 +288,26 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
-        self.assertFalse(hasattr(self.config, "hidden_listings_file"))
-        self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
-        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+        # DID configure correctly.
+        #
+        # PR #93 added ``hidden_listings_file`` to the shared ``_make_config``
+        # fixture so the HiddenListingsTestCase cases could round-trip it
+        # through the shim. That change is incompatible with the original
+        # form of this test, which asserted the fixture DID NOT have the
+        # attribute. Give this case its own SimpleNamespace with the field
+        # intentionally absent so the missing-attribute branch of
+        # ``_path_key`` is still exercised end-to-end, without disturbing
+        # the other cases that need the attribute set.
+        config = _make_config(self.base)
+        del config.hidden_listings_file
+        self.assertFalse(hasattr(config, "hidden_listings_file"))
+        storage = SqlStorageService(config)
+        self.assertEqual(storage.load_json_file(self.base / "unknown.json", []), [])
+        storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
         # A path that IS configured must still route correctly.
-        self.storage.set_user_role("still-works@example.com", "renter")
+        storage.set_user_role("still-works@example.com", "renter")
         self.assertEqual(
-            self.storage.get_user_roles(),
+            storage.get_user_roles(),
             {"still-works@example.com": "renter"},
         )
 


### PR DESCRIPTION
## Summary
Two small, orthogonal backend fixes rolled into one PR so CI can go green.

### 1. `contract_download` now logs `send_file` failures instead of hiding them as 404s
`/contracts/<id>/download` verifies both the contract's storage row **and** the resolved PDF path on disk before invoking `send_file`, so any exception from `send_file` is a real fault mode — a race with an admin delete unlinking the PDF between the `exists()` check and Flask's `open()`, a permission problem on the upload dir, or a truncated PDF. The handler swallowed all of them as a bare `abort(404)`, leaving the renter with a bogus "contract not found" and admins with no log trail.

- Log the exception (with `contract_id` + resolved path) through `current_app.logger.exception` before falling back to 404.
- Keep the response at 404 for behavior compatibility and to avoid leaking a partial body that `send_file` may have already started streaming.
- Added regression test `test_contract_download_logs_when_send_file_raises_after_exists_check` that mocks `send_file` to raise `PermissionError` after both existence checks pass, asserts the response is 404, and pins the log message contents (`contract_download`, `contract_id`, `PermissionError`) via `assertLogs(app.logger, level="ERROR")`.

### 2. `test_sql_storage`: unstick the pre-existing red main CI
CI has been red on `main` since PRs #94 and #93 landed the same day with logically-conflicting fixture assumptions — #94's regression test `test_missing_config_attribute_is_treated_as_unknown_path` asserts the shared `_make_config` does **not** set `hidden_listings_file`, but #93 added that attribute to the same fixture so `HiddenListingsTestCase` could round-trip it through the path shim. Git merged both cleanly (different lines) and the assertion has failed every run since. Multiple prior daily-maintenance PRs (#115, #116, #118, #119, #120) opened for this exact regression are still stalled.

- Give the affected test its own `SimpleNamespace`, then `del` the `hidden_listings_file` attribute so the missing-attribute branch of `_path_key` is still exercised end-to-end.
- Shared fixture is untouched, so `HiddenListingsTestCase` and the other cases that need the attribute set are unaffected.

## Test plan
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 882 tests pass, 1 skipped, 0 failures
- [x] `ruff check .` — clean
- [x] Focused: `test_contract_download_serves_pdf`, `test_contract_download_404_when_unknown`, `test_contract_download_logs_when_send_file_raises_after_exists_check` — all green
- [x] Focused: `test_missing_config_attribute_is_treated_as_unknown_path` — now green
- [ ] CI green on the PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtHR9dkKRAV9reBRjgRngL)_