### PR TITLE
Unblock red CI + validate AppointmentService.book inputs

### DIFF
--- a/somewheria_app/services/appointments.py
+++ b/somewheria_app/services/appointments.py
@@ -86,9 +86,31 @@ class AppointmentService:
 
     def book(self, property_id: str, iso_date: str) -> bool:
         # Returns True when the booking was newly recorded, False when the
-        # date was already taken for that property. Load+save run under the
-        # same lock so a second caller cannot squeeze in between and produce
-        # a double-booking on the same property/date.
+        # date was already taken for that property (or the inputs were
+        # rejected). Load+save run under the same lock so a second caller
+        # cannot squeeze in between and produce a double-booking on the
+        # same property/date.
+        #
+        # Reject inputs the on-disk format cannot round-trip. The
+        # appointments file is line-oriented ``property_id:date1,date2``;
+        # the load side splits on the first ``:``, filters empty property
+        # ids, and drops empty dates from the comma-separated set. A caller
+        # bypassing the route's upstream validation with an empty value or
+        # one containing ``:`` / ``,`` / a newline would otherwise get
+        # ``True`` back from a booking whose next ``load()`` silently drops
+        # the row, so a repeat "already booked" caller cannot happen and a
+        # cascade of ghost True's stacks up in the file. Rejecting here
+        # matches ``PROPERTY_ID_PATTERN`` (colon and comma are already
+        # forbidden by the route) and turns a silent corruption into a
+        # visible ``False`` at the boundary.
+        if not isinstance(property_id, str) or not property_id.strip():
+            return False
+        if not isinstance(iso_date, str) or not iso_date.strip():
+            return False
+        if any(bad in property_id for bad in (":", ",", "\n", "\r")):
+            return False
+        if any(bad in iso_date for bad in (":", ",", "\n", "\r")):
+            return False
         with self._lock:
             appointments = self.load()
             booked = appointments.setdefault(property_id, set())

--- a/test_services.py
+++ b/test_services.py
@@ -569,6 +569,48 @@ class AppointmentServiceTestCase(unittest.TestCase):
         self.assertEqual(loaded["prop-1"], {"2030-05-01", "2030-05-02"})
         self.assertEqual(loaded["prop-2"], {"2030-05-01"})
 
+    def test_book_rejects_empty_property_id(self):
+        # An empty / whitespace property id would setdefault a "" key and
+        # persist a ``:date`` line the next load() silently drops, so the
+        # booking is lost and the caller can't tell. Reject at the boundary.
+        self.assertFalse(self.service.book("", "2030-05-01"))
+        self.assertFalse(self.service.book("   ", "2030-05-01"))
+        self.assertFalse(self.appointments_path.exists())
+
+    def test_book_rejects_empty_iso_date(self):
+        # An empty iso_date lands as ``prop-1:`` on disk; load() then filters
+        # the empty date out and returns an empty set, so the "booked" date is
+        # gone. Refusing here surfaces the failure to the caller.
+        self.assertFalse(self.service.book("prop-1", ""))
+        self.assertFalse(self.service.book("prop-1", "   "))
+        self.assertFalse(self.appointments_path.exists())
+
+    def test_book_rejects_property_id_containing_format_delimiters(self):
+        # ``:`` is the property_id/dates separator, ``,`` splits the dates,
+        # and a newline ends a record — any of these embedded in an id would
+        # produce a line load() misparses (best case: one lost booking; worst
+        # case: two properties collapse into one).
+        for bad_id in ("bad:id", "bad,id", "bad\nid", "bad\rid"):
+            self.assertFalse(self.service.book(bad_id, "2030-05-01"), bad_id)
+        self.assertFalse(self.appointments_path.exists())
+
+    def test_book_rejects_iso_date_containing_format_delimiters(self):
+        # Same rationale as the property-id case: a ``,`` in a date joins
+        # two dates into one on the wire; a ``:`` shifts the boundary between
+        # property_id and dates; a newline splits one record into two.
+        for bad_date in ("2030-05-01,2030-05-02", "2030-05-01:12:00", "2030\n05-01"):
+            self.assertFalse(self.service.book("prop-1", bad_date), bad_date)
+        self.assertFalse(self.appointments_path.exists())
+
+    def test_book_rejects_non_string_inputs(self):
+        # Defensive: a caller passing an int/None/bytes would otherwise trip
+        # str-only paths inside load()/save() with a less obvious error.
+        self.assertFalse(self.service.book(None, "2030-05-01"))
+        self.assertFalse(self.service.book("prop-1", None))
+        self.assertFalse(self.service.book(123, "2030-05-01"))
+        self.assertFalse(self.service.book("prop-1", 20300501))
+        self.assertFalse(self.appointments_path.exists())
+
     def test_load_skips_empty_property_id_line(self):
         # A line stored with an empty property id (``:2030-01-10``) would
         # otherwise land in the returned map under the "" key and get

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,17 +288,25 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
-        self.assertFalse(hasattr(self.config, "hidden_listings_file"))
-        self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
-        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+        # DID configure correctly.
+        #
+        # The shared ``_make_config`` fixture deliberately sets
+        # ``hidden_listings_file`` (the other cases in
+        # ``HiddenListingsTestCase`` need it to route through the path
+        # shim). Build a local ``SimpleNamespace`` with that attribute
+        # stripped so this case actually exercises the missing-attribute
+        # branch of ``_path_key``'s ``getattr(..., None)`` fallback.
+        stripped_config = SimpleNamespace(
+            **{k: v for k, v in vars(self.config).items() if k != "hidden_listings_file"}
+        )
+        self.assertFalse(hasattr(stripped_config, "hidden_listings_file"))
+        storage = SqlStorageService(stripped_config)
+        self.assertEqual(storage.load_json_file(self.base / "unknown.json", []), [])
+        storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
         # A path that IS configured must still route correctly.
-        self.storage.set_user_role("still-works@example.com", "renter")
+        storage.set_user_role("still-works@example.com", "renter")
         self.assertEqual(
-            self.storage.get_user_roles(),
+            storage.get_user_roles(),
             {"still-works@example.com": "renter"},
         )
 


### PR DESCRIPTION
## Summary

Two independent fixes rolled into one PR because #1 is a hard prerequisite for #2's CI to be evaluated.

### 1. Unblock CI on `main`
CI has been red on `main` since bab1219 (7 commits back). `test_missing_config_attribute_is_treated_as_unknown_path` in `test_sql_storage.py` asserts the shared `_make_config` fixture does **not** set `hidden_listings_file`, but PR #93 (bd1d1a3) extended `_make_config` to include that attribute so `HiddenListingsTestCase` could round-trip through the path shim. The two changes merged cleanly and left the self-check contradicting the fixture.

The test's stated intent is *"if a config forgets one of the known file attributes, the shim falls through to the unknown-path branch instead of raising."* Give this one case its own `SimpleNamespace` (with `hidden_listings_file` stripped off via `del`-equivalent kwargs) so the missing-attribute branch of `_path_key`'s `getattr(..., None)` fallback is actually exercised end-to-end, while the other cases keep the attribute they need.

Not weakening any check — the previous assertion was contradicting the fixture and never actually reached the code path it claimed to. This restores the intended coverage.

_(Note: PRs #115, #116, #120 also attempt this fix; each is untouched since it opened. Landing this one — or any of those — unblocks the pipeline.)_

### 2. Validate `AppointmentService.book` inputs
`book()` accepted any string for `property_id` / `iso_date` and passed them straight into the line-oriented on-disk format (`property_id:date1,date2`). Empty values, or ones containing `:` / `,` / a newline, silently corrupted the file:

- an empty `property_id` becomes `":date"`, which the next `load()` filters out
- an empty `iso_date` becomes `"prop:"`, whose dates set is empty
- a `,` in the date joins two dates; a `:` in the id shifts the boundary; a newline splits one record into two

Either way, `book()` returned `True`, so a caller bypassing the route's upstream validation would believe the booking landed. The route (`schedule_appointment`) already validates via `PROPERTY_ID_PATTERN` and `datetime.date.fromisoformat`, so this is a defensive belt at the service boundary: reject non-string, empty, and delimiter-containing inputs so a direct caller (test, future route, ad-hoc script) fails visibly instead of silently.

## Test plan

- [x] `python -m unittest discover` → `Ran 886 tests in ~140s / OK (skipped=1)` (was 881, +5 for the new `book()` validation cases)
- [x] `ruff check .` clean
- [x] Verified the previously-failing `test_missing_config_attribute_is_treated_as_unknown_path` now passes and still asserts the missing-attribute contract it was designed for

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fz1JNdnhcSf9NCHoURMwQR)_