### PR TITLE
Fix red CI on main: strip attr in missing-config-attr shim test

### DIFF
--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,10 +288,11 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
+        # DID configure correctly. Delete one attribute the shim knows
+        # about so this test exercises exactly that "missing attribute"
+        # branch; ``_make_config`` sets every known attribute, so simulate
+        # the older-config scenario by stripping one out here.
+        del self.config.hidden_listings_file
         self.assertFalse(hasattr(self.config, "hidden_listings_file"))
         self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])


### PR DESCRIPTION
## Summary

CI has been red on every push to `main` since PRs #93 and #94 merged concurrently. This restores the suite to green (881 tests, was 881 with 1 failure).

## The regression

Two independent PRs interacted badly at merge time:

- **bd1d1a3** ("Restore CI: extend SqlStorage test fixture to hidden_listings_file") added `hidden_listings_file` to `test_sql_storage._make_config` so earlier PathShim tests would stop crashing on `AttributeError`.
- **41efab1** ("Make SqlStorageService._path_key tolerant of missing config attributes (#94)") added `test_missing_config_attribute_is_treated_as_unknown_path`, whose first assertion is `assertFalse(hasattr(self.config, "hidden_listings_file"))`.

Neither PR was wrong on its own branch, but after both landed the fixture now sets that attribute — so the new regression test fails immediately at the `assertFalse(hasattr(...))`.

## The fix

The test's intent — "verify the shim tolerates a config missing a known file attribute" — is still correct; it just needs to actively strip the attribute rather than rely on the fixture omitting it. `del self.config.hidden_listings_file` restores that scenario at test time, with an updated comment so future readers see why.

## Test plan
- [x] `python -m unittest test_sql_storage` — 33 tests pass locally
- [x] `python -m unittest discover` — full suite: 881 tests, `OK (skipped=1)` locally
- [x] `ruff check .` — clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4rezoLWbVPv6havG7R8aE)_