### PR TITLE
Fix contradictory assertion in SqlStorage missing-attr test

### DIFF
--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,17 +288,34 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
-        self.assertFalse(hasattr(self.config, "hidden_listings_file"))
-        self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
-        self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
-        # A path that IS configured must still route correctly.
-        self.storage.set_user_role("still-works@example.com", "renter")
+        # DID configure correctly.
+        #
+        # The shared ``_make_config`` fixture DOES set every known attribute
+        # (bd1d1a3 added ``hidden_listings_file`` to keep CI green), so this
+        # test builds an independent, deliberately incomplete config and
+        # points a fresh SqlStorageService at it to exercise the branch
+        # directly. Depending on what the fixture happens to include today
+        # made the test flaky against future fixture edits.
+        partial_config = SimpleNamespace(
+            registration_file=self.base / "pending_registrations.json",
+            user_roles_file=self.base / "user_roles.json",
+            renter_profile_file=self.base / "renter_profiles.json",
+            contracts_file=self.base / "renter_contracts.json",
+            tickets_file=self.base / "tickets.json",
+            lead_capture_file=self.base / "pending_lead_captures.json",
+            # ``hidden_listings_file`` intentionally omitted.
+            sqlite_file=self.base / "partial.sqlite3",
+        )
+        self.assertFalse(hasattr(partial_config, "hidden_listings_file"))
+        partial_storage = SqlStorageService(partial_config)
         self.assertEqual(
-            self.storage.get_user_roles(),
+            partial_storage.load_json_file(self.base / "unknown.json", []), []
+        )
+        partial_storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
+        # A path that IS configured must still route correctly.
+        partial_storage.set_user_role("still-works@example.com", "renter")
+        self.assertEqual(
+            partial_storage.get_user_roles(),
             {"still-works@example.com": "renter"},
         )
 


### PR DESCRIPTION
## Summary

`test_missing_config_attribute_is_treated_as_unknown_path` in `test_sql_storage.py` currently fails on `main`: it asserts `assertFalse(hasattr(self.config, "hidden_listings_file"))`, but the shared `_make_config` fixture sets that attribute (added in bd1d1a3 to keep CI green after the hidden-listings bucket landed). The test was introduced in 41efab1 and has been red on `main` since.

Rewrite the test so it doesn't depend on the shared fixture's contents:

- Build an independent `SimpleNamespace` config that deliberately omits `hidden_listings_file` (and no other attributes it might legitimately grow).
- Instantiate a fresh `SqlStorageService` against that config.
- Exercise the same three assertions (unknown-path load returns default, unknown-path save no-ops, configured path still routes correctly) against the isolated storage instance.

Now the "missing attribute" branch of `_path_key` is exercised regardless of what the shared fixture happens to include — future additions to `_make_config` no longer break this test.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest test_sql_storage.PathShimUnknownPathTestCase` — all 3 tests pass
- [x] `DISABLE_BACKGROUND_THREADS=1 python -m unittest discover` — 881 tests pass, 1 skipped (previously: 1 failure)
- [x] `ruff check .` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdpnsH6Y8Aam4R5XnCDDHi)_