### PR TITLE
Tighten pets inference and repair the missing-attr sql shim test

### DIFF
--- a/somewheria_app/services/properties.py
+++ b/somewheria_app/services/properties.py
@@ -733,8 +733,13 @@ class PropertyService:
                 # whose description reads "No pets allowed" would have its
                 # explicit "No" flipped to "Yes" by the substring match.
                 # Negations are checked first so that inference itself can
-                # produce "No", and \bpet keeps carpet/trumpet/puppet from
-                # matching at all.
+                # produce "No". The affirmative pattern anchors both edges of
+                # "pet"/"pets" as a whole word — the earlier ``\bpet`` prefix
+                # match falsely fired "Yes" on unrelated words that happen to
+                # start with those letters (``petunias`` in a garden blurb,
+                # ``petition``, ``petroleum``); ``\bpets?\b`` still catches
+                # legitimate mentions like "pet friendly", "small pet ok",
+                # or "pets welcome" without those false positives.
                 amenity_text = " ".join(
                     str(item).lower()
                     for item in normalized.get("included_amenities", [])
@@ -745,7 +750,7 @@ class PropertyService:
                     searchable,
                 ):
                     pets_allowed = "No"
-                elif re.search(r"\bpet", searchable):
+                elif re.search(r"\bpets?\b", searchable):
                     pets_allowed = "Yes"
                 else:
                     pets_allowed = "Unknown"

--- a/test_services.py
+++ b/test_services.py
@@ -734,6 +734,44 @@ class PropertyServiceTestCase(unittest.TestCase):
         self.assertEqual(normalized["included_amenities"], [])
         self.assertEqual(normalized["pets_allowed"], "Yes")
 
+    def test_normalize_property_pets_inference_ignores_words_starting_with_pet(self):
+        # The old ``\bpet`` prefix match fired on unrelated words that happen
+        # to start with the same three letters — a garden blurb mentioning
+        # "petunias", a legal note mentioning a "petition", or any listing
+        # that quoted a "petroleum" fixture would flip ``pets_allowed`` to
+        # "Yes" even though no pet policy was described. The whole-word
+        # ``\bpets?\b`` anchor should leave those cases as "Unknown".
+        for description in (
+            "Wraparound garden with mature petunias and roses.",
+            "Prior owner filed a petition to rezone the lot.",
+            "Historic block; petroleum lantern fixtures preserved.",
+        ):
+            normalized = self.service.normalize_property(
+                {"name": "Maple", "description": description}, "prop-1"
+            )
+            self.assertEqual(
+                normalized["pets_allowed"],
+                "Unknown",
+                msg=f"false pet inference for description {description!r}",
+            )
+
+    def test_normalize_property_pets_inference_still_matches_pet_and_pets(self):
+        # Confirm the tightened regex still catches the affirmative phrasings
+        # the previous behavior was actually there to handle.
+        for description in (
+            "Small pet allowed with prior approval.",
+            "Pets welcome; deposit applies.",
+            "Cat-friendly unit — one pet limit.",
+        ):
+            normalized = self.service.normalize_property(
+                {"name": "Maple", "description": description}, "prop-1"
+            )
+            self.assertEqual(
+                normalized["pets_allowed"],
+                "Yes",
+                msg=f"missed pet inference for description {description!r}",
+            )
+
     def test_normalize_property_coerces_non_list_included_amenities_to_empty_list(self):
         # A malformed upstream payload that returns a string (or any other
         # non-list) for included_amenities must not crash; the string would

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,10 +288,13 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
+        # DID configure correctly. Strip a known attribute here to
+        # exercise the ``getattr(..., None)`` fallback in ``_path_key``:
+        # the stock fixture now lists every configured file (commit
+        # bd1d1a3 extended it with ``hidden_listings_file`` to restore
+        # CI), so the test has to remove one intentionally to keep
+        # covering the missing-attribute contract.
+        del self.config.hidden_listings_file
         self.assertFalse(hasattr(self.config, "hidden_listings_file"))
         self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])
@@ -301,6 +304,13 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
             self.storage.get_user_roles(),
             {"still-works@example.com": "renter"},
         )
+        # And the previously-configured path (now missing) itself falls
+        # through to the "unknown path" branch, exercising getattr's
+        # None default rather than the equality comparison that would
+        # otherwise raise AttributeError.
+        removed_path = self.base / "hidden_listings.json"
+        self.assertEqual(self.storage.load_json_file(removed_path, []), [])
+        self.storage.save_json_file(removed_path, ["prop-1"])
 
 
 class AtomicTestCase(SqlStorageBaseTestCase):


### PR DESCRIPTION
## Summary

Two independent fixes plus test coverage — both surfaced while surveying `main` for real backend issues.

### 1. Pets-allowed inference no longer fires on unrelated `pet*` words

`PropertyService.normalize_property` runs a fallback inference when the upstream `pets_allowed` value is missing or unrecognized: it walks the description + amenities and matches a small set of patterns. The affirmative branch was a bare `\bpet` prefix, so any word that merely started with those three letters flipped the flag to `"Yes"`:

| Description | Old inference | Fixed inference |
| --- | --- | --- |
| `Wraparound garden with mature petunias…` | `Yes` | `Unknown` |
| `Prior owner filed a petition to rezone…` | `Yes` | `Unknown` |
| `Historic block; petroleum lantern fixtures…` | `Yes` | `Unknown` |
| `Small pet allowed…` | `Yes` | `Yes` |
| `Pets welcome; deposit applies.` | `Yes` | `Yes` |
| `Cat-friendly unit — one pet limit.` | `Yes` | `Yes` |

Anchoring both edges (`\bpets?\b`) still catches the legitimate phrasings we care about. The negation branch already used `\bpets?\b`, so this brings the affirmative branch into alignment with it.

### 2. `test_missing_config_attribute_is_treated_as_unknown_path` was failing on `main`

Baseline `python -m unittest discover` on `origin/main`:

```
FAIL: test_missing_config_attribute_is_treated_as_unknown_path
AssertionError: True is not false
Ran 881 tests in 177.893s
FAILED (failures=1, skipped=1)
```

Commit `bd1d1a3` extended the `_make_config` fixture with `hidden_listings_file` to restore CI, but this particular test asserts `assertFalse(hasattr(self.config, "hidden_listings_file"))` as its precondition — the contract it pins for `SqlStorageService._path_key` is *"a config missing a known file attribute must fall through to unknown-path, not raise AttributeError"*. With the fixture now providing every attribute, the test was structurally impossible to pass and stopped exercising what it was written to cover.

Fix: delete the attribute in-test so the `getattr(..., None)` fallback in `_path_key` is genuinely exercised, then load AND save against the newly-missing path to confirm the shim routes to "unknown path" instead of AttributeErroring halfway through the attribute comparisons.

## Test plan

- [x] `python -m unittest discover` — was 881 pass + 1 fail; now **883 pass + 0 fail** (1 skipped, matches baseline).
- [x] `python -m unittest test_sql_storage.PathShimUnknownPathTestCase` — targeted rerun of the previously-failing case.
- [x] `python -m unittest test_services.PropertyServiceTestCase` — includes the two new false-positive / true-positive coverage tests.
- [x] `ruff check somewheria_app/ test_services.py test_sql_storage.py` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_019aDw9buJZYySJ4sLNSfX2u)_