### PR TITLE
Sanitize inbound X-Request-Id; restore CI

### DIFF
--- a/somewheria_app/__init__.py
+++ b/somewheria_app/__init__.py
@@ -1,4 +1,5 @@
 import os
+import re
 import threading
 import time
 import traceback
@@ -33,6 +34,36 @@ from .services.zillow import ZillowPublisher
 
 def _is_development() -> bool:
     return os.getenv("FLASK_ENV", "production").lower() in ("development", "dev", "local")
+
+
+# Opaque-token character set for a trace id: alphanumerics and the three
+# separators load balancers actually use. Anything outside this set (tabs,
+# spaces, quotes, angle brackets, control chars, unicode) would corrupt one
+# of the places the id ends up: the ConsoleFormatter's ``[{request_id}]``
+# tag would split on an embedded tab or space; the echoed
+# ``X-Request-Id`` response header would carry attacker-controlled text
+# back to any downstream log parser; and JSON log ingestion tools that
+# treat the value as a search key would trip on delimiters.
+_SAFE_REQUEST_ID_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def _sanitize_request_id(raw: str) -> str:
+    """Return ``raw`` if it is a plausible opaque trace id, else ``""``.
+
+    The previous flow accepted any truthy header value up to 64 chars, so a
+    client-supplied ``X-Request-Id: "   "`` (whitespace) or ``"a\tb"`` (tab)
+    became the id — and then landed in the ConsoleFormatter's ``[<id>]`` log
+    tag, splitting the log line or producing an empty-looking tag. Reject the
+    whole header rather than partially stripping so a caller who set a bad
+    value gets a fresh UUID and can see (via the echoed response header)
+    that we didn't honor their id.
+    """
+    if not raw:
+        return ""
+    trimmed = raw.strip()[:64]
+    if not trimmed or not _SAFE_REQUEST_ID_RE.fullmatch(trimmed):
+        return ""
+    return trimmed
 
 
 def create_app() -> Flask:
@@ -119,8 +150,8 @@ def create_app() -> Flask:
     # X-Request-Id (e.g. from a future load balancer) is honored when present.
     @app.before_request
     def _assign_request_id():
-        incoming = request.headers.get("X-Request-Id", "")
-        g.request_id = (incoming[:64] or uuid.uuid4().hex[:8])
+        incoming = _sanitize_request_id(request.headers.get("X-Request-Id", ""))
+        g.request_id = incoming or uuid.uuid4().hex[:8]
 
     # The role is resolved once at login and cached in the session cookie, so
     # without this hook a promotion/demotion/revocation made in the admin UI

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -111,6 +111,38 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         response = self.client.get("/", headers={"X-Request-Id": "trace-me-123"})
         self.assertEqual(response.headers.get("X-Request-Id"), "trace-me-123")
 
+    def test_inbound_request_id_with_tab_is_rejected(self):
+        # A tab inside the id would split the ConsoleFormatter's ``[<id>]``
+        # log tag and get echoed verbatim into the response header. Reject
+        # the whole header and generate a fresh id rather than trying to
+        # strip the bad character (the client can see, via the echoed
+        # header, that we didn't honor their trace id).
+        response = self.client.get("/", headers={"X-Request-Id": "a\tb"})
+        returned = response.headers.get("X-Request-Id", "")
+        self.assertNotEqual(returned, "a\tb")
+        self.assertNotIn("\t", returned)
+        self.assertTrue(returned)
+
+    def test_inbound_request_id_whitespace_only_is_rejected(self):
+        # An id of only whitespace previously became the request_id and
+        # produced an empty-looking ``[   ]`` tag in every log line the
+        # request emitted; fall back to a fresh UUID instead.
+        response = self.client.get("/", headers={"X-Request-Id": "   "})
+        returned = response.headers.get("X-Request-Id", "")
+        self.assertNotEqual(returned.strip(), "")
+        self.assertNotEqual(returned, "   ")
+
+    def test_inbound_request_id_with_disallowed_chars_is_rejected(self):
+        # An id carrying angle brackets, quotes, or other delimiters would
+        # be echoed straight back into the response header and into every
+        # log line. Reject anything outside the safe opaque-token set so
+        # a hostile client can't inject content into either sink.
+        response = self.client.get("/", headers={"X-Request-Id": "abc<script>"})
+        returned = response.headers.get("X-Request-Id", "")
+        self.assertNotEqual(returned, "abc<script>")
+        self.assertNotIn("<", returned)
+        self.assertNotIn(">", returned)
+
     def test_auth_status_returns_authenticated_payload(self):
         self.login_as("renter", email="renter@example.com", name="Renter User")
 

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,10 +288,14 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
+        # DID configure correctly. The shared ``_make_config`` now sets
+        # every attribute the shim knows about (bd1d1a3 added
+        # ``hidden_listings_file`` there to keep the other
+        # PathShimUnknownPathTestCase tests reachable), so simulate the
+        # "older config" case by removing the newest attribute after
+        # construction. Without this deletion the assertion below trips
+        # and the fixture change silently masks the missing-attr branch.
+        del self.config.hidden_listings_file
         self.assertFalse(hasattr(self.config, "hidden_listings_file"))
         self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])


### PR DESCRIPTION
## Summary

Two independent fixes.

### 1. Reject unsafe `X-Request-Id` header values

The `_assign_request_id` before_request hook in `somewheria_app/__init__.py` accepted any truthy client-supplied `X-Request-Id` value up to 64 chars and used it verbatim as `g.request_id`. That id then lands in three places:

- the `ConsoleFormatter`'s `[<id>]` log tag,
- the JSON log's `request_id` field consumed by `notifications.read_logs`,
- the echoed `X-Request-Id` response header.

Reproduced with the app's test client:

| Header value | Old behavior |
| --- | --- |
| `"   "` (whitespace only) | `g.request_id == "   "`, log lines carried a `[   ]` tag |
| `"a\tb"` (tab) | `[a\tb]` split the ConsoleFormatter output |
| `"abc<script>"` | echoed unchanged into `X-Request-Id` response header and every log line |

Fix: sanitize the value through `_sanitize_request_id`, which trims, caps at 64 chars, and requires the whole result to match `[A-Za-z0-9._-]+` — the opaque-token character set real load balancers actually emit. Anything outside that set is rejected as a whole and the request gets a fresh UUID, mirroring what a caller with no header sees. Rejecting rather than partially stripping means a client that set a bad value can see from the echoed response header that we didn't honor their trace id.

Adds three regression tests to `test_routes_expanded.py` that pin the reject-with-fallback behavior for tab, whitespace-only, and angle-bracket payloads. The existing `trace-me-123` happy-path test still passes unchanged.

### 2. Restore CI on `main`

`test_missing_config_attribute_is_treated_as_unknown_path` opens with `assertFalse(hasattr(self.config, "hidden_listings_file"))`, but `_make_config` (updated in `bd1d1a3` to keep the other `PathShimUnknownPathTestCase` tests reachable) sets that attribute on every fixture. The assertion has been failing on `main` from PR #93 onward with `AssertionError: True is not false`, which would also red the CI on this branch and block the merge above.

Fix: `del self.config.hidden_listings_file` at the top of the test so it still exercises the "older-config" branch it was written for, without regressing the fixture the other tests rely on. Same one-liner already staged in #125 / #118; included here so this PR can land while those are still open.

## Test plan

- [x] `DISABLE_BACKGROUND_THREADS=1 FLASK_ENV=development SECRET_KEY=ci-only-not-for-prod python -m unittest discover` — 884 tests pass, 1 skipped (previously: 1 failure)
- [x] `ruff check .` — clean
- [x] Manual repro with `app.test_client()`: whitespace/tab/HTML-injection payloads now fall through to a UUID and the log tag is clean

---
_Generated by [Claude Code](https://claude.ai/code/session_0189u7dCHtE4Ln2LK75dPGQd)_