### PR TITLE
Restore CI + surface report-issue email failures instead of dropping them

### DIFF
--- a/somewheria_app/routes/public_routes.py
+++ b/somewheria_app/routes/public_routes.py
@@ -323,10 +323,28 @@ def report_issue():
     issue_description = (request.form.get("description") or "").strip()[:MAX_DESCRIPTION_LEN]
     if not user_name or not issue_description:
         return "Name and description are required fields.", 400
-    services.notifications.send_email(
+    # Only render the confirmation page when the report actually reached the
+    # admin inbox. ``send_email`` returns False when EMAIL_APP_PASSWORD is
+    # missing or the SMTP send raised — the previous flow discarded that
+    # signal, so a user submitting during an SMTP outage saw the confirmation
+    # page while the report went nowhere. Mirror ``contact_submit``: surface
+    # the failure to the admin log (which will also send the alert email once
+    # the outage clears, thanks to the crash-alert dedupe key) and give the
+    # user a real error rather than a silent drop.
+    delivered = services.notifications.send_email(
         "User Reported Issue",
         f"Issue reported by {user_name}:\n\n{issue_description}",
     )
+    if not delivered:
+        services.notifications.log_and_notify_error(
+            "Issue Report Delivery Failure",
+            f"Issue report from {user_name} could not be emailed: {issue_description}",
+        )
+        return (
+            "Sorry — we couldn't send your report just now. "
+            "Please email or call us directly.",
+            503,
+        )
     return render_template(
         "report_issue.html",
         title="Report an Issue",

--- a/test_generated_matrices.py
+++ b/test_generated_matrices.py
@@ -122,6 +122,15 @@ class GeneratedRouteMatrixTestCase(unittest.TestCase):
                 stack.enter_context(patch.object(self.services.properties, "fetch_live_property_name", return_value="Maple House"))
                 stack.enter_context(patch.object(self.services.appointments, "book", return_value=True))
                 stack.enter_context(patch.object(self.services.notifications, "send_email"))
+            if path == "/report-issue":
+                # Stand in for a working SMTP relay so the matrix continues
+                # to assert the happy-path status code. The route now returns
+                # 503 when send_email reports a failure (unset
+                # EMAIL_APP_PASSWORD, SMTP outage), which is the correct
+                # behaviour but is NOT what this matrix is designed to cover.
+                stack.enter_context(
+                    patch.object(self.services.notifications, "send_email", return_value=True)
+                )
             if path == "/google/login":
                 self.services.config.google_client_id = "client-id"
                 self.services.config.google_client_secret = "client-secret"

--- a/test_routes_expanded.py
+++ b/test_routes_expanded.py
@@ -408,7 +408,9 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"Name and description are required fields.", response.data)
 
     def test_report_issue_sends_email_and_renders_confirmation(self):
-        with patch.object(self.services.notifications, "send_email") as send_email_mock:
+        with patch.object(
+            self.services.notifications, "send_email", return_value=True
+        ) as send_email_mock:
             response = self.client.post(
                 "/report-issue",
                 data={"name": "Jamie", "description": "Broken contact form"},
@@ -418,6 +420,30 @@ class ExpandedRouteCoverageTestCase(unittest.TestCase):
         self.assertIn(b"Jamie", response.data)
         send_email_mock.assert_called_once()
         self.assertIn("User Reported Issue", send_email_mock.call_args[0][0])
+
+    def test_report_issue_surfaces_send_failure_instead_of_confirming(self):
+        # When SMTP is unreachable (or EMAIL_APP_PASSWORD is unset), the
+        # report has actually gone nowhere — showing the "thank you" page
+        # was a silent drop. Route must return an error status AND route
+        # the failure through log_and_notify_error so the admin can see
+        # (in application.log) that a report was lost.
+        with patch.object(
+            self.services.notifications, "send_email", return_value=False
+        ) as send_email_mock, patch.object(
+            self.services.notifications, "log_and_notify_error"
+        ) as log_mock:
+            response = self.client.post(
+                "/report-issue",
+                data={"name": "Jamie", "description": "Broken contact form"},
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertNotIn(b"your report has been submitted", response.data)
+        send_email_mock.assert_called_once()
+        log_mock.assert_called_once()
+        self.assertIn(
+            "Issue Report Delivery Failure", log_mock.call_args[0][0]
+        )
 
     def test_register_page_loads(self):
         response = self.client.get("/register")

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -288,10 +288,14 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
+        # DID configure correctly.
+        #
+        # Simulate the mismatch by dropping ``hidden_listings_file`` from
+        # the fixture. The fixture sets it (bd1d1a3 added it to keep the
+        # rest of the path-shim tests reachable), so we explicitly delete
+        # it here to exercise the "attribute absent" path this test exists
+        # to pin.
+        del self.config.hidden_listings_file
         self.assertFalse(hasattr(self.config, "hidden_listings_file"))
         self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])


### PR DESCRIPTION
## Summary

Two unrelated backend fixes bundled into one PR.

### 1. Restore green CI

`test_missing_config_attribute_is_treated_as_unknown_path` was failing on `main` — it contradicted its own fixture:

- The test asserted `hasattr(config, "hidden_listings_file") == False`.
- But `bd1d1a3` had added `hidden_listings_file` to `_make_config` so the rest of the path-shim tests could reach their assertions (adding a new storage bucket without extending the fixture broke CI back then; removing it again would re-break those neighbours).

Fix: delete the attribute from `self.config` right before the assertion. This preserves the test's original intent (a config missing a known storage attribute must fall through to the `_path_key` "unknown path" branch instead of raising `AttributeError`) while leaving the fixture attribute in place for every other test that depends on it.

### 2. `/report-issue` silently dropped user reports on SMTP failure

The route discarded `send_email`'s return value and always rendered the "your report has been submitted" confirmation page. `NotificationService.send_email` returns `False` when `EMAIL_APP_PASSWORD` is missing or the SMTP send raised — under either condition the report went nowhere, the admin got no notification, no local record was kept, and the user thought their report was received.

Fix: mirror `contact_submit` in the same file.

- Check the `send_email` return value.
- On failure, funnel through `log_and_notify_error` so the miss lands in `application.log` (and is emailed once the relay recovers, thanks to the 10‑min crash‑alert dedupe key).
- Return `503` with a short "please email or call us directly" message instead of a fake success page.

Also updates the `/report-issue` POST fixture in `test_generated_matrices` to patch `send_email` to return `True`, so the happy‑path status expectations in the route matrix stay valid; a new failure‑path test in `test_routes_expanded` pins the new 503 + `log_and_notify_error` behaviour.

## Test plan

- [x] `python -m unittest discover` — 882 tests pass locally (was 1 failure on `main`)
- [x] `ruff check .` — clean
- [x] New failure-path test `test_report_issue_surfaces_send_failure_instead_of_confirming` asserts 503 + `log_and_notify_error` on `send_email(...) == False`
- [x] Existing `test_report_issue_sends_email_and_renders_confirmation` still passes (updated the mock to `return_value=True` for explicitness)
- [x] Generated route matrix continues to expect 200 for `/report-issue` POST across all roles (SMTP is patched to succeed)

---
_Generated by [Claude Code](https://claude.ai/code/session_014m5pJw4JR2gnCsFuvMo9iJ)_