### PR TITLE
Restore CI + skip no-op user_role revocation writes

### DIFF
--- a/somewheria_app/services/sql_storage.py
+++ b/somewheria_app/services/sql_storage.py
@@ -190,11 +190,18 @@ class SqlStorageService:
         with self.db.transaction() as conn:
             row = conn.execute("SELECT role FROM user_roles WHERE email = ?", (email,)).fetchone()
             previous = row["role"] if row else None
+            # Nothing to change: absent means no local role to revoke, and an
+            # existing "revoked" tombstone is already the target state. Skip
+            # the SQL write in both cases so a bulk admin sweep that hits the
+            # already-revoked path doesn't churn the DB for no effect. Mirrors
+            # the FileStorageService change in the same commit.
+            if previous is None or previous == "revoked":
+                return False
             conn.execute(
                 "INSERT OR REPLACE INTO user_roles(email, role) VALUES (?, ?)",
                 (email, "revoked"),
             )
-        return previous is not None and previous != "revoked"
+        return True
 
     def _replace_user_roles(self, data: dict) -> None:
         with self.db.transaction() as conn:

--- a/somewheria_app/services/storage.py
+++ b/somewheria_app/services/storage.py
@@ -132,12 +132,20 @@ class FileStorageService:
         with self.file_lock:
             roles = self.get_user_roles()
             previous = roles.get(email)
+            # Nothing to change: absent means no local role to revoke, and an
+            # existing "revoked" tombstone is already the target state. Skip
+            # the disk write in both cases — a bulk admin sweep that hits the
+            # already-revoked path used to rewrite the whole file for no
+            # effect (same shape as the set_email_updates no-op fix in
+            # commit 38390e2).
+            if previous is None or previous == "revoked":
+                return False
             # Store a tombstone ("revoked") instead of removing the key outright
             # so that env-var fallbacks in AuthService.get_user_role cannot
             # silently restore a deleted user's access on their next login.
             roles[email] = "revoked"
             self.save_json_file(self.config.user_roles_file, roles)
-        return previous is not None and previous != "revoked"
+        return True
 
     def get_renter_profiles(self) -> dict:
         return self.load_json_file(self.config.renter_profile_file, {}, expected_type=dict)

--- a/test_services.py
+++ b/test_services.py
@@ -331,6 +331,10 @@ class FileStorageServiceTestCase(unittest.TestCase):
         save_json_mock.assert_called_once_with(self.config.user_roles_file, {"admin@example.com": "revoked"})
 
     def test_delete_user_role_returns_false_when_missing(self):
+        # An absent user has no local role to revoke: skip the disk write
+        # entirely rather than persisting a tombstone for a nonexistent key
+        # (which would pollute user_roles.json with rows for every
+        # hand-crafted POST hitting an unknown email).
         with patch.object(self.service, "get_user_roles", return_value={}), patch.object(
             self.service,
             "save_json_file",
@@ -338,7 +342,21 @@ class FileStorageServiceTestCase(unittest.TestCase):
             removed = self.service.delete_user_role("missing@example.com")
 
         self.assertFalse(removed)
-        save_json_mock.assert_called_once_with(self.config.user_roles_file, {"missing@example.com": "revoked"})
+        save_json_mock.assert_not_called()
+
+    def test_delete_user_role_no_op_when_already_revoked(self):
+        # Re-revoking an already-revoked user must NOT rewrite the file: it
+        # doesn't change disk state and would otherwise churn on repeated
+        # admin action or a bulk sweep.
+        with patch.object(
+            self.service,
+            "get_user_roles",
+            return_value={"gone@example.com": "revoked"},
+        ), patch.object(self.service, "save_json_file") as save_json_mock:
+            removed = self.service.delete_user_role("gone@example.com")
+
+        self.assertFalse(removed)
+        save_json_mock.assert_not_called()
 
     def test_save_renter_profiles_delegates_to_save_json_file(self):
         profiles = {"renter@example.com": {"name": "Jamie"}}

--- a/test_sql_storage.py
+++ b/test_sql_storage.py
@@ -64,6 +64,22 @@ class UserRolesTestCase(SqlStorageBaseTestCase):
     def test_delete_user_role_returns_false_when_absent(self):
         existed = self.storage.delete_user_role("ghost@example.com")
         self.assertFalse(existed)
+        # And leaves no row behind: an absent user has no local role to
+        # revoke, so we skip the SQL write instead of inserting a phantom
+        # tombstone keyed to an email that has never logged in.
+        self.assertEqual(self.storage.get_user_roles(), {})
+
+    def test_delete_user_role_no_op_when_already_revoked(self):
+        # Re-revoking an already-revoked user must NOT re-write the row: no
+        # state change and no reason to churn the DB on repeat admin action
+        # or a bulk sweep.
+        self.storage.set_user_role("gone@example.com", "renter")
+        self.assertTrue(self.storage.delete_user_role("gone@example.com"))
+        # Second delete: same target state, so returns False and no-ops.
+        self.assertFalse(self.storage.delete_user_role("gone@example.com"))
+        self.assertEqual(
+            self.storage.get_user_roles(), {"gone@example.com": "revoked"}
+        )
 
 
 class PendingRegistrationsTestCase(SqlStorageBaseTestCase):
@@ -288,10 +304,15 @@ class PathShimUnknownPathTestCase(SqlStorageBaseTestCase):
         # shim must fall through to the "unknown path" branch rather than
         # raising AttributeError halfway through the checks. That would
         # abort load/save for every path — including the ones the config
-        # DID configure correctly. The stock ``_make_config`` doesn't set
-        # ``hidden_listings_file`` at all, so the shim already needs to
-        # tolerate the missing attribute; if it doesn't, an unknown-path
-        # load raises AttributeError instead of returning the default.
+        # DID configure correctly. Delete a known attribute here to simulate
+        # a config that's out of sync, then verify the shim still returns
+        # the default for an unknown path and still routes the paths it does
+        # know about correctly. Without this delattr the assertion below
+        # trips against the shared ``_make_config`` fixture — bd1d1a3 added
+        # ``hidden_listings_file`` there to keep the other path-shim tests
+        # reachable, so the "attribute absent" branch has to be simulated
+        # per test.
+        delattr(self.config, "hidden_listings_file")
         self.assertFalse(hasattr(self.config, "hidden_listings_file"))
         self.assertEqual(self.storage.load_json_file(self.base / "unknown.json", []), [])
         self.storage.save_json_file(self.base / "unknown.json", [{"x": 1}])


### PR DESCRIPTION
## Summary

Two backend fixes that share the same "don't churn on unchanged state" theme, plus the CI-unblocker:

- **Restore green CI.** `test_missing_config_attribute_is_treated_as_unknown_path` in `test_sql_storage.py` opens with `assertFalse(hasattr(self.config, "hidden_listings_file"))`, but bd1d1a3 (the fixture-extension PR) added that attribute to `_make_config` so the *other* `PathShimUnknownPathTestCase` tests could reach their assertions. That precondition has been failing on every CI run since. `delattr(self.config, "hidden_listings_file")` inside the test simulates the "older config" scenario the test exists to pin, without regressing the fixture the other tests rely on.

- **Skip no-op tombstone writes.** `FileStorageService.delete_user_role` and `SqlStorageService.delete_user_role` were rewriting the entire `user_roles.json` (or issuing a redundant `INSERT OR REPLACE`) even when the target user had no local role or was already a `"revoked"` tombstone. The return value already said "nothing changed" (False), but the write happened anyway — so a bulk admin sweep or repeat click churned disk / DB for no effect, and a POST hitting an unknown email would still leave a phantom tombstone behind. Both backends now short-circuit when `previous is None or previous == "revoked"` and return False without writing. Same shape as the `set_email_updates` no-op fix in commit 38390e2.

## Test plan

- [x] `python -m unittest discover` → 883 tests, all green locally
- [x] `ruff check .` → clean
- [x] Two new positive-path tests (one per backend) pin the already-revoked no-op so the write can't sneak back in
- [x] Confirmed the previously-failing test now passes with the `delattr` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ1AL5oeeM6KccEfieor8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJ1AL5oeeM6KccEfieor8i)_